### PR TITLE
Autofreeze ability

### DIFF
--- a/src/main/java/com/flippingutilities/FlippingConfig.java
+++ b/src/main/java/com/flippingutilities/FlippingConfig.java
@@ -95,4 +95,15 @@ public interface FlippingConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+			keyName = "autoFreezeMargin",
+			name = "automatically freeze the margin of every new item.",
+			description = "Ensures that every item that gets added has its margin frozen to prevent its "
+					+ "margin from being updated by subsequent buys/sells of one."
+	)
+	default boolean autoFreezeMargin()
+	{
+		return false;
+	}
 }

--- a/src/main/java/com/flippingutilities/FlippingConfig.java
+++ b/src/main/java/com/flippingutilities/FlippingConfig.java
@@ -98,7 +98,8 @@ public interface FlippingConfig extends Config
 
 	@ConfigItem(
 			keyName = "autoFreezeMargin",
-			name = "automatically freeze the margin of every new item.",
+			name = "Automatically freeze the margin of new items.",
+
 			description = "Ensures that every item that gets added has its margin frozen to prevent its "
 					+ "margin from being updated by subsequent buys/sells of one."
 	)

--- a/src/main/java/com/flippingutilities/FlippingPlugin.java
+++ b/src/main/java/com/flippingutilities/FlippingPlugin.java
@@ -138,7 +138,7 @@ public class FlippingPlugin extends Plugin
 		// I wanted to put it below the GE plugin, but can't as the GE and world switcher buttonhave the same priority...
 		navButton = NavigationButton.builder()
 			.tooltip("Flipping Plugin")
-			.icon(ImageUtil.getResourceStreamFromClass(getClass(), "/util/graphIconGreen.png"))
+			.icon(ImageUtil.getResourceStreamFromClass(getClass(), "/graphIconGreen.png"))
 			.priority(3)
 			.panel(panel)
 			.build();

--- a/src/main/java/com/flippingutilities/FlippingPlugin.java
+++ b/src/main/java/com/flippingutilities/FlippingPlugin.java
@@ -138,7 +138,7 @@ public class FlippingPlugin extends Plugin
 		// I wanted to put it below the GE plugin, but can't as the GE and world switcher buttonhave the same priority...
 		navButton = NavigationButton.builder()
 			.tooltip("Flipping Plugin")
-			.icon(ImageUtil.getResourceStreamFromClass(getClass(), "/graphIconGreen.png"))
+			.icon(ImageUtil.getResourceStreamFromClass(getClass(), "/util/graphIconGreen.png"))
 			.priority(3)
 			.panel(panel)
 			.build();
@@ -386,6 +386,12 @@ public class FlippingPlugin extends Plugin
 				flippingItem.setLatestBuyTime(tradeTime);
 			}
 		}
+
+		//When you have finished margin checking an item (when both the buy and sell prices have been set) and the auto
+    //freeze config option has been selected, freeze the item's margin.
+		if (!(flippingItem.getLatestBuyPrice()==0) && !(flippingItem.getLatestSellPrice()==0) && config.autoFreezeMargin())  {
+        flippingItem.setFrozen(true);
+    }
 		flippingItem.updateGELimitReset();
 	}
 

--- a/src/main/java/com/flippingutilities/FlippingPlugin.java
+++ b/src/main/java/com/flippingutilities/FlippingPlugin.java
@@ -388,10 +388,12 @@ public class FlippingPlugin extends Plugin
 		}
 
 		//When you have finished margin checking an item (when both the buy and sell prices have been set) and the auto
-    //freeze config option has been selected, freeze the item's margin.
-		if (!(flippingItem.getLatestBuyPrice()==0) && !(flippingItem.getLatestSellPrice()==0) && config.autoFreezeMargin())  {
-        flippingItem.setFrozen(true);
-    }
+		//freeze config option has been selected, freeze the item's margin.
+		if (!(flippingItem.getLatestBuyPrice()==0) && !(flippingItem.getLatestSellPrice()==0) && config.autoFreezeMargin())
+		{
+			flippingItem.setFrozen(true);
+		}
+
 		flippingItem.updateGELimitReset();
 	}
 


### PR DESCRIPTION
Created the ability to auto freeze margins through a config option the user can set. By default it is false, so the default behavior of the plugin is the same. I found myself freezing margins on pretty much every item, so I thought the ability to auto freeze would be handy.