### PR TITLE
potential bug fix for widget dissapearing on logout

### DIFF
--- a/src/main/java/com/flippingutilities/FlippingPlugin.java
+++ b/src/main/java/com/flippingutilities/FlippingPlugin.java
@@ -541,10 +541,9 @@ public class FlippingPlugin extends Plugin
 
 		clientThread.invokeLater(() ->
 		{
-			if (flippingWidget == null)
-			{
-				flippingWidget = new FlippingItemWidget(client.getWidget(WidgetInfo.CHATBOX_CONTAINER), client);
-			}
+
+			flippingWidget = new FlippingItemWidget(client.getWidget(WidgetInfo.CHATBOX_CONTAINER), client);
+
 
 			FlippingItem selectedItem = null;
 			//Check that if we've recorded any data for the item.


### PR DESCRIPTION
The widget for setting prices/quantities, etc disappears when you logout. It's there on the first start of the client, but when you logout and log back in, it never appears. I tried tracing the bug, but everything works down to showWidget. There are no errors thrown or anything, the text literally just doesn't show up. It's really odd. 

The change I made fixed it. I figured if it works the first time the client starts up, let me simulate that - by recreating it every time -.-.  I have a hunch this isn't the actual way to fix it (who knows), but I don't know anything about runelite widgets and so I thought this could be temporary until the real fix is found (if this one isn't good).

Feel free to reject this PR if you know a better fix as you probably know more about widgets than me :)