### PR TITLE
Realtime ge limit tracking along with fix to ge refresh algorithm.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 build
 .idea/
 src/.idea/
+out/

--- a/src/main/java/com/flippingutilities/FlippingItem.java
+++ b/src/main/java/com/flippingutilities/FlippingItem.java
@@ -41,7 +41,7 @@ public class FlippingItem
 	private static int GE_RESET_TIME_SECONDS = 60 * 60 * 4;
 
 	@Getter
-	private ArrayList<GrandExchangeTrade> tradeHistory;
+	private ArrayList<OfferInfo> tradeHistory;
 
 	@Getter
 	private final int itemId;
@@ -80,9 +80,9 @@ public class FlippingItem
 
 	private HistoryManager history;
 
-	public void updateHistory(GrandExchangeTrade newTrade)
+	public void updateHistory(OfferInfo newTrade)
 	{
-		history.updateHistory((OfferInfo) newTrade);
+		history.updateHistory(newTrade);
 	}
 
 	public int currentProfit(Instant earliestTime)
@@ -90,7 +90,7 @@ public class FlippingItem
 		return history.currentProfit(earliestTime);
 	}
 
-	public void addTradeHistory(final GrandExchangeTrade trade)
+	public void addTradeHistory(final OfferInfo trade)
 	{
 		tradeHistory.add(trade);
 	}
@@ -99,11 +99,11 @@ public class FlippingItem
 	{
 		if (tradeHistory != null)
 		{
-			GrandExchangeTrade oldestTrade = null;
+			OfferInfo oldestTrade = null;
 			remainingGELimit = totalGELimit;
 
 			//Check for the oldest trade within the last 4 hours.
-			for (GrandExchangeTrade trade : tradeHistory)
+			for (OfferInfo trade : tradeHistory)
 			{
 				if (trade.isBuy() && trade.getTime().getEpochSecond() >= Instant.now().minusSeconds(GE_RESET_TIME_SECONDS).getEpochSecond())
 				{

--- a/src/main/java/com/flippingutilities/FlippingItem.java
+++ b/src/main/java/com/flippingutilities/FlippingItem.java
@@ -32,7 +32,6 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
-import net.runelite.http.api.ge.GrandExchangeTrade;
 
 @Slf4j
 @AllArgsConstructor

--- a/src/main/java/com/flippingutilities/FlippingItemPanel.java
+++ b/src/main/java/com/flippingutilities/FlippingItemPanel.java
@@ -79,11 +79,13 @@ public class FlippingItemPanel extends JPanel
 
 	static
 	{
-		final BufferedImage openIcon = ImageUtil.getResourceStreamFromClass(FlippingPlugin.class, "/open-arrow.png");
+		final BufferedImage openIcon = ImageUtil
+			.getResourceStreamFromClass(FlippingPlugin.class, "/open-arrow.png");
 		CLOSE_ICON = new ImageIcon(openIcon);
 		OPEN_ICON = new ImageIcon(ImageUtil.rotateImage(openIcon, Math.toRadians(90)));
 
-		final BufferedImage deleteIcon = ImageUtil.getResourceStreamFromClass(FlippingPlugin.class, "/delete_icon.png");
+		final BufferedImage deleteIcon = ImageUtil
+			.getResourceStreamFromClass(FlippingPlugin.class, "/delete_icon.png");
 		DELETE_ICON = new ImageIcon(deleteIcon);
 	}
 
@@ -113,7 +115,8 @@ public class FlippingItemPanel extends JPanel
 	JPanel leftInfoTextPanel = new JPanel(new GridLayout(7, 1));
 	JPanel rightValuesPanel = new JPanel(new GridLayout(7, 1));
 
-	FlippingItemPanel(final FlippingPlugin plugin, final ItemManager itemManager, final FlippingItem flippingItem)
+	FlippingItemPanel(final FlippingPlugin plugin, final ItemManager itemManager,
+					  final FlippingItem flippingItem)
 	{
 		this.flippingItem = flippingItem;
 		this.buyPrice = this.flippingItem.getLatestBuyPrice();
@@ -259,8 +262,10 @@ public class FlippingItemPanel extends JPanel
 		buyPriceText.setToolTipText("The buy price according to your latest margin check");
 		sellPriceText.setToolTipText("The sell price according to your latest margin check");
 		profitEachText.setToolTipText("The profit margin according to your latest margin check");
-		profitTotalText.setToolTipText("The total profit according to your latest margin check and GE 4-hour limit");
-		ROILabel.setToolTipText("<html>Return on investment:<br>Percentage of profit relative to gp invested</html>");
+		profitTotalText.setToolTipText(
+			"The total profit according to your latest margin check and GE 4-hour limit");
+		ROILabel.setToolTipText(
+			"<html>Return on investment:<br>Percentage of profit relative to gp invested</html>");
 		limitLabel.setToolTipText("The amount you can buy of this item every 4 hours.");
 
 		profitEachVal.setToolTipText(profitEachText.getToolTipText());
@@ -327,24 +332,31 @@ public class FlippingItemPanel extends JPanel
 		updateProfits();
 		SwingUtilities.invokeLater(() ->
 		{
-			buyPriceVal.setText((this.buyPrice == 0) ? "N/A" : String.format(NUM_FORMAT, this.buyPrice) + " gp");
-			sellPriceVal.setText((this.sellPrice == 0) ? "N/A" : String.format(NUM_FORMAT, this.sellPrice) + " gp");
+			buyPriceVal
+				.setText((this.buyPrice == 0) ? "N/A" : String.format(NUM_FORMAT, this.buyPrice) + " gp");
+			sellPriceVal.setText(
+				(this.sellPrice == 0) ? "N/A" : String.format(NUM_FORMAT, this.sellPrice) + " gp");
 
-			profitEachVal.setText((this.buyPrice == 0 || this.sellPrice == 0) ? "N/A" : QuantityFormatter.quantityToRSDecimalStack(profitEach) + " gp");
-			profitTotalVal.setText((this.buyPrice == 0 || this.sellPrice == 0) ? "N/A" : QuantityFormatter.quantityToRSDecimalStack(profitTotal) + " gp");
+			profitEachVal.setText((this.buyPrice == 0 || this.sellPrice == 0) ? "N/A"
+				: QuantityFormatter.quantityToRSDecimalStack(profitEach) + " gp");
+			profitTotalVal.setText((this.buyPrice == 0 || this.sellPrice == 0) ? "N/A" : QuantityFormatter
+				.quantityToRSDecimalStack(profitTotal) + " gp");
 
-			ROILabel.setText("ROI:  " + ((buyPrice == 0 || sellPrice == 0 || profitEach <= 0) ? "N/A" : String.format("%.2f", ROI) + "%"));
+			ROILabel.setText("ROI:  " + ((buyPrice == 0 || sellPrice == 0 || profitEach <= 0) ? "N/A"
+				: String.format("%.2f", ROI) + "%"));
 		});
 
 		//Color gradient red-yellow-green depending on ROI.
 		if (ROI < roiGradientMax * 0.5)
 		{
-			Color gradientRedToYellow = ColorUtil.colorLerp(Color.RED, Color.YELLOW, ROI / roiGradientMax * 2);
+			Color gradientRedToYellow = ColorUtil
+				.colorLerp(Color.RED, Color.YELLOW, ROI / roiGradientMax * 2);
 			SwingUtilities.invokeLater(() -> ROILabel.setForeground(gradientRedToYellow));
 		}
 		else
 		{
-			Color gradientYellowToGreen = (ROI >= roiGradientMax) ? Color.GREEN : ColorUtil.colorLerp(Color.YELLOW, Color.GREEN, ROI / roiGradientMax * 0.5);
+			Color gradientYellowToGreen = (ROI >= roiGradientMax) ? Color.GREEN : ColorUtil
+				.colorLerp(Color.YELLOW, Color.GREEN, ROI / roiGradientMax * 0.5);
 			SwingUtilities.invokeLater(() -> ROILabel.setForeground(gradientYellowToGreen));
 		}
 	}
@@ -383,11 +395,14 @@ public class FlippingItemPanel extends JPanel
 		if (plugin.getConfig().geLimitProfit())
 		{
 			this.profitTotal = (flippingItem.getRemainingGELimit() == 0) ? 0
-				: flippingItem.getRemainingGELimit() * profitEach - (plugin.getConfig().marginCheckLoss() ? profitEach : 0);
+				: flippingItem.getRemainingGELimit() * profitEach - (plugin.getConfig().marginCheckLoss()
+				? profitEach : 0);
 		}
 		else
 		{
-			this.profitTotal = flippingItem.getTotalGELimit() * profitEach - (plugin.getConfig().marginCheckLoss() ? profitEach : 0);
+			this.profitTotal =
+				flippingItem.getTotalGELimit() * profitEach - (plugin.getConfig().marginCheckLoss()
+					? profitEach : 0);
 		}
 		this.ROI = calculateROI();
 	}
@@ -410,8 +425,12 @@ public class FlippingItemPanel extends JPanel
 		final String latestSellString = formatPriceTimeText(latestSellTime) + " old";
 
 		//As the config unit is in minutes.
-		final int latestBuyTimeAgo = latestBuyTime != null ? (int) (Instant.now().getEpochSecond() - latestBuyTime.getEpochSecond()) : 0;
-		final int latestSellTimeAgo = latestSellTime != null ? (int) (Instant.now().getEpochSecond() - latestSellTime.getEpochSecond()) : 0;
+		final int latestBuyTimeAgo =
+			latestBuyTime != null ? (int) (Instant.now().getEpochSecond() - latestBuyTime
+				.getEpochSecond()) : 0;
+		final int latestSellTimeAgo =
+			latestSellTime != null ? (int) (Instant.now().getEpochSecond() - latestSellTime
+				.getEpochSecond()) : 0;
 
 		//Check if, according to the user-defined settings, prices are outdated, else set default color.
 		if (latestBuyTimeAgo != 0 && latestBuyTimeAgo / 60 > plugin.getConfig().outOfDateWarning())
@@ -419,7 +438,8 @@ public class FlippingItemPanel extends JPanel
 			SwingUtilities.invokeLater(() ->
 			{
 				buyPriceVal.setForeground(OUTDATED_COLOR);
-				buyPriceVal.setToolTipText("<html>" + OUTDATED_STRING + "<br>" + latestBuyString + "</html>");
+				buyPriceVal
+					.setToolTipText("<html>" + OUTDATED_STRING + "<br>" + latestBuyString + "</html>");
 			});
 
 		}
@@ -438,7 +458,8 @@ public class FlippingItemPanel extends JPanel
 			SwingUtilities.invokeLater(() ->
 			{
 				sellPriceVal.setForeground(OUTDATED_COLOR);
-				sellPriceVal.setToolTipText("<html>" + OUTDATED_STRING + "<br>" + latestSellString + "</html>");
+				sellPriceVal
+					.setToolTipText("<html>" + OUTDATED_STRING + "<br>" + latestSellString + "</html>");
 			});
 
 		}
@@ -503,25 +524,31 @@ public class FlippingItemPanel extends JPanel
 	{
 		SwingUtilities.invokeLater(() ->
 		{
-			if (flippingItem.getGeLimitResetTime() != null && flippingItem.getGeLimitResetTime().isBefore(Instant.now()))
+			if (flippingItem.getGeLimitResetTime() != null && flippingItem.getGeLimitResetTime()
+				.isBefore(Instant.now()))
 			{
 				flippingItem.resetGELimit();
 			}
 
-			limitLabel.setText("GE limit: " + String.format(NUM_FORMAT, flippingItem.getRemainingGELimit()));
+			limitLabel
+				.setText("GE limit: " + String.format(NUM_FORMAT, flippingItem.getRemainingGELimit()));
 			if (flippingItem.getGeLimitResetTime() == null)
 			{
 				limitLabel.setToolTipText("None has been bought in the past 4 hours.");
 			}
 			else
 			{
-				final long remainingSeconds = flippingItem.getGeLimitResetTime().getEpochSecond() - Instant.now().getEpochSecond();
+				final long remainingSeconds =
+					flippingItem.getGeLimitResetTime().getEpochSecond() - Instant.now().getEpochSecond();
 				final long remainingMinutes = remainingSeconds / 60 % 60;
 				final long remainingHours = remainingSeconds / 3600 % 24;
-				String timeString = String.format("%02d:%02d ", remainingHours, remainingMinutes) + (remainingHours > 1 ? "hours" : "hour");
+				String timeString =
+					String.format("%02d:%02d ", remainingHours, remainingMinutes) + (remainingHours > 1
+						? "hours" : "hour");
 
 				limitLabel.setToolTipText("<html>" + "GE limit is reset in " + timeString + "."
-					+ "<br>This will be at " + formatGELimitResetTime(flippingItem.getGeLimitResetTime()) + ".<html>");
+					+ "<br>This will be at " + formatGELimitResetTime(flippingItem.getGeLimitResetTime())
+					+ ".<html>");
 			}
 		});
 	}

--- a/src/main/java/com/flippingutilities/FlippingPanel.java
+++ b/src/main/java/com/flippingutilities/FlippingPanel.java
@@ -79,7 +79,8 @@ public class FlippingPanel extends PluginPanel
 
 	static
 	{
-		final BufferedImage resetIcon = ImageUtil.getResourceStreamFromClass(FlippingPlugin.class, "/reset.png");
+		final BufferedImage resetIcon = ImageUtil
+			.getResourceStreamFromClass(FlippingPlugin.class, "/reset.png");
 		RESET_ICON = new ImageIcon(resetIcon);
 		RESET_HOVER_ICON = new ImageIcon(ImageUtil.alphaOffset(resetIcon, 0.53f));
 	}

--- a/src/main/java/com/flippingutilities/FlippingPlugin.java
+++ b/src/main/java/com/flippingutilities/FlippingPlugin.java
@@ -70,7 +70,6 @@ import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.ClientToolbar;
 import net.runelite.client.ui.NavigationButton;
 import net.runelite.client.util.ImageUtil;
-import net.runelite.http.api.ge.GrandExchangeTrade;
 import net.runelite.http.api.item.ItemStats;
 
 @Slf4j
@@ -318,18 +317,19 @@ public class FlippingPlugin extends Plugin
 	{
 		GrandExchangeOffer offer = newOfferEvent.getOffer();
 
-		OfferInfo offerInfo = new OfferInfo();
-		offerInfo.setBuy(
-			offer.getState() == GrandExchangeOfferState.BOUGHT ||
-				offer.getState() == GrandExchangeOfferState.CANCELLED_BUY ||
-				offer.getState() == GrandExchangeOfferState.BUYING);
-		offerInfo.setItemId(offer.getItemId());
-		offerInfo.setPrice(offer.getSpent() / offer.getQuantitySold());
-		offerInfo.setQuantity(offer.getQuantitySold());
-		offerInfo.setTime(Instant.now());
-		offerInfo.setSlot(newOfferEvent.getSlot());
-		offerInfo.setState(offer.getState());
+		boolean isBuy = offer.getState() == GrandExchangeOfferState.BOUGHT || offer.getState() == GrandExchangeOfferState.CANCELLED_BUY || offer.getState() == GrandExchangeOfferState.BUYING;
+
+		OfferInfo offerInfo = new OfferInfo(
+			isBuy,
+			offer.getItemId(),
+			offer.getQuantitySold(),
+			offer.getSpent() / offer.getQuantitySold(),
+			Instant.now(),
+			newOfferEvent.getSlot(),
+			offer.getState());
+
 		return offerInfo;
+
 	}
 
 	//Adds GE trade data to the trades list.

--- a/src/main/java/com/flippingutilities/FlippingPlugin.java
+++ b/src/main/java/com/flippingutilities/FlippingPlugin.java
@@ -238,8 +238,7 @@ public class FlippingPlugin extends Plugin
 		int newOfferSlot = newOfferEvent.getSlot();
 
 		//Check for login screen and empty offers.
-		if (newOffer.getQuantitySold() == 0 || newOfferEvent.getOffer().getItemId() == 0 || client.getWidget(
-			WidgetInfo.LOGIN_CLICK_TO_PLAY_SCREEN) != null)
+		if (newOffer.getQuantitySold() == 0 || newOfferEvent.getOffer().getItemId() == 0)
 		{
 			return true;
 		}

--- a/src/main/java/com/flippingutilities/FlippingPlugin.java
+++ b/src/main/java/com/flippingutilities/FlippingPlugin.java
@@ -239,7 +239,8 @@ public class FlippingPlugin extends Plugin
 		int newOfferSlot = newOfferEvent.getSlot();
 
 		//Check for login screen and empty offers.
-		if (newOffer.getQuantitySold() == 0 || newOfferEvent.getOffer().getItemId() == 0 || client.getWidget(WidgetInfo.LOGIN_CLICK_TO_PLAY_SCREEN) != null)
+		if (newOffer.getQuantitySold() == 0 || newOfferEvent.getOffer().getItemId() == 0 || client.getWidget(
+			WidgetInfo.LOGIN_CLICK_TO_PLAY_SCREEN) != null)
 		{
 			return true;
 		}

--- a/src/main/java/com/flippingutilities/FlippingPlugin.java
+++ b/src/main/java/com/flippingutilities/FlippingPlugin.java
@@ -288,7 +288,6 @@ public class FlippingPlugin extends Plugin
 	@Subscribe
 	public void onGrandExchangeOfferChanged(GrandExchangeOfferChanged newOfferEvent)
 	{
-
 		if (isBadEvent(newOfferEvent))
 		{
 			return;
@@ -315,7 +314,7 @@ public class FlippingPlugin extends Plugin
 		panel.updateGELimit();
 	}
 
-	private GrandExchangeTrade tradeConstructor(GrandExchangeOfferChanged newOfferEvent)
+	private OfferInfo tradeConstructor(GrandExchangeOfferChanged newOfferEvent)
 	{
 		GrandExchangeOffer offer = newOfferEvent.getOffer();
 
@@ -334,7 +333,7 @@ public class FlippingPlugin extends Plugin
 	}
 
 	//Adds GE trade data to the trades list.
-	public void addFlipTrade(GrandExchangeTrade trade)
+	public void addFlipTrade(OfferInfo trade)
 	{
 		if (tradesList == null)
 		{
@@ -369,14 +368,14 @@ public class FlippingPlugin extends Plugin
 	}
 
 	//Constructs a FlippingItem and adds it to the tradeList.
-	private void addToTradesList(GrandExchangeTrade trade)
+	private void addToTradesList(OfferInfo trade)
 	{
 		int tradeItemId = trade.getItemId();
 		String itemName = itemManager.getItemComposition(tradeItemId).getName();
 
 		ItemStats itemStats = itemManager.getItemStats(tradeItemId, false);
 		int tradeGELimit = itemStats != null ? itemStats.getGeLimit() : 0;
-		ArrayList<GrandExchangeTrade> tradeHistory = new ArrayList<GrandExchangeTrade>()
+		ArrayList<OfferInfo> tradeHistory = new ArrayList<OfferInfo>()
 		{{
 			add(trade);
 		}};
@@ -411,7 +410,7 @@ public class FlippingPlugin extends Plugin
 	}
 
 	//Updates the latest margins writes history for a Flipping Item
-	private void updateFlip(FlippingItem flippingItem, GrandExchangeTrade trade)
+	private void updateFlip(FlippingItem flippingItem, OfferInfo trade)
 	{
 		boolean tradeBuyState = trade.isBuy();
 		int tradePrice = trade.getPrice();

--- a/src/main/java/com/flippingutilities/HistoryManager.java
+++ b/src/main/java/com/flippingutilities/HistoryManager.java
@@ -75,7 +75,7 @@ public class HistoryManager
 			standardizedOffers.add(standardizedOffer);
 			currentTradesForSlot.add(newOffer);
 
-			//if the offer is complete, delete the history for that slot.
+			//if the offer is complete, clear the history for that slot.
 			if (newOffer.isComplete())
 			{
 				slotHistory.remove(newOfferSlot);
@@ -113,7 +113,7 @@ public class HistoryManager
 		}
 		// when the time of the last offer (most recent offer) is greater than nextGeLimitRefresh,
 		// you know the ge limits have refreshed. Since this is the first offer after the ge limits
-		// have refreshed, the next refresh will be four after this offer's buy time.
+		// have refreshed, the next refresh will be four hours after this offer's buy time.
 		if (nextGeLimitRefresh == null || lastOffer.getTime().compareTo(nextGeLimitRefresh) > 0)
 		{
 			nextGeLimitRefresh = lastOffer.getTime().plus(4, ChronoUnit.HOURS);

--- a/src/main/java/com/flippingutilities/HistoryManager.java
+++ b/src/main/java/com/flippingutilities/HistoryManager.java
@@ -7,6 +7,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.swing.plaf.basic.BasicInternalFrameTitlePane;
 import lombok.Getter;
 import net.runelite.api.events.GrandExchangeOfferChanged;
 
@@ -25,6 +26,7 @@ public class HistoryManager
 	//a list of standardizedOffers. A standardizedOffer is an offer with a quantity that represents the
 	//quantity bought since the last offer. A regular offer just has info from an offerEvent, which gives
 	//you the current quantity bought/sold overall in the trade.
+	@Getter
 	private List<OfferInfo> standardizedOffers = new ArrayList<>();
 
 	@Getter
@@ -113,7 +115,7 @@ public class HistoryManager
 		// when the time of the last offer (most recent offer) is greater than nextGeLimitRefresh,
 		// you know the ge limits have refreshed. Since this is the first offer after the ge limits
 		// have refreshed, the next refresh will be four after this offer's buy time.
-		if (nextGeLimitRefresh == null || lastOffer.getTime().compareTo(nextGeLimitRefresh) > 1)
+		if (nextGeLimitRefresh == null || lastOffer.getTime().compareTo(nextGeLimitRefresh) > 0)
 		{
 			nextGeLimitRefresh = lastOffer.getTime().plus(4, ChronoUnit.HOURS);
 			itemsBoughtThisLimitWindow = lastOffer.getQuantity();
@@ -151,6 +153,7 @@ public class HistoryManager
 			//later than the time the user selected (if they selected 4 hours, its all trades after 4 hours ago.
 			if (standardizedOffer.getTime().compareTo(earliestTime) > 0)
 			{
+
 				if (standardizedOffer.isBuy())
 				{
 					numBoughtItems += standardizedOffer.getQuantity();

--- a/src/main/java/com/flippingutilities/HistoryManager.java
+++ b/src/main/java/com/flippingutilities/HistoryManager.java
@@ -7,7 +7,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.swing.plaf.basic.BasicInternalFrameTitlePane;
 import lombok.Getter;
 import net.runelite.api.events.GrandExchangeOfferChanged;
 

--- a/src/main/java/com/flippingutilities/HistoryManager.java
+++ b/src/main/java/com/flippingutilities/HistoryManager.java
@@ -106,24 +106,24 @@ public class HistoryManager
 	 */
 	private void updateGeProperties()
 	{
-		OfferInfo lastOffer = standardizedOffers.get(standardizedOffers.size() - 1);
-		if (!lastOffer.isBuy())
+		OfferInfo mostRecentOffer = standardizedOffers.get(standardizedOffers.size() - 1);
+		if (!mostRecentOffer.isBuy())
 		{
 			return;
 		}
 		// when the time of the last offer (most recent offer) is greater than nextGeLimitRefresh,
 		// you know the ge limits have refreshed. Since this is the first offer after the ge limits
 		// have refreshed, the next refresh will be four hours after this offer's buy time.
-		if (nextGeLimitRefresh == null || lastOffer.getTime().compareTo(nextGeLimitRefresh) > 0)
+		if (nextGeLimitRefresh == null || mostRecentOffer.getTime().compareTo(nextGeLimitRefresh) > 0)
 		{
-			nextGeLimitRefresh = lastOffer.getTime().plus(4, ChronoUnit.HOURS);
-			itemsBoughtThisLimitWindow = lastOffer.getQuantity();
+			nextGeLimitRefresh = mostRecentOffer.getTime().plus(4, ChronoUnit.HOURS);
+			itemsBoughtThisLimitWindow = mostRecentOffer.getQuantity();
 		}
 		//if the last offer (most recent offer) is before the next ge limit refresh, add its quantity to the
 		//amount bought this limit window.
 		else
 		{
-			itemsBoughtThisLimitWindow += lastOffer.getQuantity();
+			itemsBoughtThisLimitWindow += mostRecentOffer.getQuantity();
 		}
 
 	}

--- a/src/main/java/com/flippingutilities/OfferInfo.java
+++ b/src/main/java/com/flippingutilities/OfferInfo.java
@@ -1,11 +1,10 @@
 package com.flippingutilities;
 
 
+import java.time.Instant;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
 import net.runelite.api.GrandExchangeOfferState;
 import net.runelite.api.events.GrandExchangeOfferChanged;
-import net.runelite.http.api.ge.GrandExchangeTrade;
 
 /**
  * This class stores information from a {@link GrandExchangeOfferChanged} event.
@@ -15,12 +14,15 @@ import net.runelite.http.api.ge.GrandExchangeTrade;
  * GrandExchangeTrade and adding two new fields that are needed for future changes, backwards
  * compatability is maintained, while allowing new work using the additional info stored in this class.
  */
-@EqualsAndHashCode(callSuper = false)
-@Data
-public class OfferInfo extends GrandExchangeTrade
-{
 
-	//new fields that weren't in GrandExchangeTrade
+@Data
+public class OfferInfo
+{
+	private boolean buy;
+	private int itemId;
+	private int quantity;
+	private int price;
+	private Instant time;
 	private int slot;
 	private GrandExchangeOfferState state;
 
@@ -54,20 +56,14 @@ public class OfferInfo extends GrandExchangeTrade
 	public OfferInfo clone()
 	{
 		OfferInfo clonedOffer = new OfferInfo();
-		clonedOffer.setBuy(isBuy());
-		clonedOffer.setItemId(getItemId());
-		clonedOffer.setQuantity(getQuantity());
-		clonedOffer.setTime(getTime()); //need to clone the instant object too. Currently this is just a reference to the old one.
+		clonedOffer.setBuy(buy);
+		clonedOffer.setItemId(itemId);
+		clonedOffer.setQuantity(quantity);
+		clonedOffer.setTime(time); //need to clone the instant object too. Currently this is just a reference to the old one.
 		clonedOffer.setSlot(slot);
 		clonedOffer.setState(state);
-		clonedOffer.setPrice(getPrice());
+		clonedOffer.setPrice(price);
 		return clonedOffer;
-	}
-
-	public String toString()
-	{
-		return "buy: " + isBuy() + " quantity: " + getQuantity() + " price each: " + getPrice() +
-			" slot " + slot + " state " + state;
 	}
 }
 

--- a/src/main/java/com/flippingutilities/OfferInfo.java
+++ b/src/main/java/com/flippingutilities/OfferInfo.java
@@ -57,7 +57,7 @@ public class OfferInfo extends GrandExchangeTrade
 		clonedOffer.setBuy(isBuy());
 		clonedOffer.setItemId(getItemId());
 		clonedOffer.setQuantity(getQuantity());
-		clonedOffer.setTime(getTime());
+		clonedOffer.setTime(getTime()); //need to clone the instant object too. Currently this is just a reference to the old one.
 		clonedOffer.setSlot(slot);
 		clonedOffer.setState(state);
 		clonedOffer.setPrice(getPrice());

--- a/src/main/java/com/flippingutilities/OfferInfo.java
+++ b/src/main/java/com/flippingutilities/OfferInfo.java
@@ -2,7 +2,9 @@ package com.flippingutilities;
 
 
 import java.time.Instant;
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.RequiredArgsConstructor;
 import net.runelite.api.GrandExchangeOfferState;
 import net.runelite.api.events.GrandExchangeOfferChanged;
 
@@ -16,6 +18,7 @@ import net.runelite.api.events.GrandExchangeOfferChanged;
  */
 
 @Data
+@AllArgsConstructor
 public class OfferInfo
 {
 	private boolean buy;
@@ -53,16 +56,10 @@ public class OfferInfo
 
 	}
 
+	//TODO actually clone the Instant object, as we are currently just passing that as the same reference.
 	public OfferInfo clone()
 	{
-		OfferInfo clonedOffer = new OfferInfo();
-		clonedOffer.setBuy(buy);
-		clonedOffer.setItemId(itemId);
-		clonedOffer.setQuantity(quantity);
-		clonedOffer.setTime(time); //need to clone the instant object too. Currently this is just a reference to the old one.
-		clonedOffer.setSlot(slot);
-		clonedOffer.setState(state);
-		clonedOffer.setPrice(price);
+		OfferInfo clonedOffer = new OfferInfo(buy, itemId, quantity, price, time, slot, state);
 		return clonedOffer;
 	}
 }

--- a/src/main/java/com/flippingutilities/OfferInfo.java
+++ b/src/main/java/com/flippingutilities/OfferInfo.java
@@ -28,6 +28,13 @@ public class OfferInfo
 	private int slot;
 	private GrandExchangeOfferState state;
 
+	/**
+	 * Returns a boolean representing that the offer is a complete offer. A complete offer signifies
+	 * the end of that trade, thus the end of the slot's history. The HistoryManager uses this to decide when
+	 * to clear the history for a slot.
+	 *
+	 * @return boolean value representing that the offer is a complete offer
+	 */
 	public boolean isComplete()
 	{
 		return

--- a/src/main/java/com/flippingutilities/OfferInfo.java
+++ b/src/main/java/com/flippingutilities/OfferInfo.java
@@ -4,7 +4,6 @@ package com.flippingutilities;
 import java.time.Instant;
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.RequiredArgsConstructor;
 import net.runelite.api.GrandExchangeOfferState;
 import net.runelite.api.events.GrandExchangeOfferChanged;
 

--- a/src/test/java/com/flippingutilities/FlippingPluginTest.java
+++ b/src/test/java/com/flippingutilities/FlippingPluginTest.java
@@ -3,12 +3,9 @@ package com.flippingutilities;
 import net.runelite.client.RuneLite;
 import net.runelite.client.externalplugins.ExternalPluginManager;
 
-import org.junit.Test;
-
 public class FlippingPluginTest
 {
 
-	@Test
 	public static void main(String[] args) throws Exception
 	{
 		ExternalPluginManager.loadBuiltin(FlippingPlugin.class);

--- a/src/test/java/com/flippingutilities/HistoryManagerTest.java
+++ b/src/test/java/com/flippingutilities/HistoryManagerTest.java
@@ -1,9 +1,113 @@
 package com.flippingutilities;
 
 
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import net.runelite.api.GrandExchangeOfferState;
+import static org.junit.Assert.assertEquals;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 
 public class HistoryManagerTest
 {
+	private static HistoryManager historyManager;
+	private static Instant baseTime = Instant.now();
+
+	@BeforeClass
+	public static void setUp() {
+		List<OfferInfo> offers = new ArrayList<>();
+		//overall bought 24+3+20=47
+		//overall sold 7 + 3 + 30 = 40
+		//5gp profit each
+		offers.add(new OfferInfo(true, 0, 7, 100, baseTime.minus(40, ChronoUnit.MINUTES), 1, GrandExchangeOfferState.BUYING));
+		offers.add(new OfferInfo(true, 0, 13, 100, baseTime.minus(30, ChronoUnit.MINUTES), 1, GrandExchangeOfferState.BUYING));
+		offers.add(new OfferInfo(true, 0, 24, 100, baseTime.minus(20, ChronoUnit.MINUTES), 1, GrandExchangeOfferState.BOUGHT));
+
+		offers.add(new OfferInfo(false, 0, 7, 105, baseTime.minus(15, ChronoUnit.MINUTES), 3, GrandExchangeOfferState.SOLD));
+		offers.add(new OfferInfo(false, 0, 3, 105, baseTime.minus(12, ChronoUnit.MINUTES), 4, GrandExchangeOfferState.SELLING));
+		offers.add(new OfferInfo(false, 0, 3, 105, baseTime.minus(12, ChronoUnit.MINUTES), 4, GrandExchangeOfferState.CANCELLED_SELL));
+
+		offers.add(new OfferInfo(true, 0, 3, 100, baseTime.minus(10, ChronoUnit.MINUTES), 2, GrandExchangeOfferState.BOUGHT));
+		offers.add(new OfferInfo(true, 0, 10, 100, baseTime.minus(9, ChronoUnit.MINUTES), 2, GrandExchangeOfferState.BUYING));
+		offers.add(new OfferInfo(true, 0, 20, 100, baseTime.minus(7, ChronoUnit.MINUTES), 2, GrandExchangeOfferState.BOUGHT));
+
+
+		offers.add(new OfferInfo(false, 0, 10, 105, baseTime.minus(6, ChronoUnit.MINUTES), 1, GrandExchangeOfferState.SELLING));
+		offers.add(new OfferInfo(false, 0, 20, 105, baseTime.minus(5, ChronoUnit.MINUTES), 1, GrandExchangeOfferState.SELLING));
+		offers.add(new OfferInfo(false, 0, 30, 105, baseTime.minus(4, ChronoUnit.MINUTES), 1, GrandExchangeOfferState.SOLD));
+
+		historyManager = new HistoryManager();
+		for (OfferInfo offer: offers) {
+			historyManager.updateHistory(offer);
+		}
+
+
+	}
+
+	@Test
+	public void offersAreCorrectlyStandardizedTest() {
+		List<OfferInfo> standardizedOffers = new ArrayList<>();
+		standardizedOffers.add(new OfferInfo(true, 0, 7, 100, baseTime.minus(40, ChronoUnit.MINUTES), 1, GrandExchangeOfferState.BUYING));
+		standardizedOffers.add(new OfferInfo(true, 0, 6, 100, baseTime.minus(30, ChronoUnit.MINUTES), 1, GrandExchangeOfferState.BUYING));
+		standardizedOffers.add(new OfferInfo(true, 0, 11, 100, baseTime.minus(20, ChronoUnit.MINUTES), 1, GrandExchangeOfferState.BOUGHT));
+
+		standardizedOffers.add(new OfferInfo(false, 0, 7, 105, baseTime.minus(15, ChronoUnit.MINUTES), 3, GrandExchangeOfferState.SOLD));
+		standardizedOffers.add(new OfferInfo(false, 0, 3, 105, baseTime.minus(12, ChronoUnit.MINUTES), 4, GrandExchangeOfferState.SELLING));
+		standardizedOffers.add(new OfferInfo(false, 0, 0, 105, baseTime.minus(12, ChronoUnit.MINUTES), 4, GrandExchangeOfferState.CANCELLED_SELL));
+
+		standardizedOffers.add(new OfferInfo(true, 0, 3, 100, baseTime.minus(10, ChronoUnit.MINUTES), 2, GrandExchangeOfferState.BOUGHT));
+		standardizedOffers.add(new OfferInfo(true, 0, 10, 100, baseTime.minus(9, ChronoUnit.MINUTES), 2, GrandExchangeOfferState.BUYING));
+		standardizedOffers.add(new OfferInfo(true, 0, 10, 100, baseTime.minus(7, ChronoUnit.MINUTES), 2, GrandExchangeOfferState.BOUGHT));
+
+
+		standardizedOffers.add(new OfferInfo(false, 0, 10, 105, baseTime.minus(6, ChronoUnit.MINUTES), 1, GrandExchangeOfferState.SELLING));
+		standardizedOffers.add(new OfferInfo(false, 0, 10, 105, baseTime.minus(5, ChronoUnit.MINUTES), 1, GrandExchangeOfferState.SELLING));
+		standardizedOffers.add(new OfferInfo(false, 0, 10, 105, baseTime.minus(4, ChronoUnit.MINUTES), 1, GrandExchangeOfferState.SOLD));
+
+
+		assertEquals(standardizedOffers, historyManager.getStandardizedOffers());
+	}
+
+	@Test
+	public void getProfitCorrectnessTest() {
+		assertEquals(200, historyManager.currentProfit(baseTime.minus(1, ChronoUnit.HOURS)));
+		historyManager.updateHistory(new OfferInfo(false, 0, 5, 105, baseTime.minus(4, ChronoUnit.MINUTES), 1, GrandExchangeOfferState.SOLD));
+		assertEquals(34*5, historyManager.currentProfit(baseTime.minus(25, ChronoUnit.MINUTES))); //34 buys and 40 sells, so looks for 34 items and profit is 5 gp ea.
+		assertEquals(0, historyManager.currentProfit(baseTime));
+
+	}
+
+	@Test
+	public void gePropertiesCorrectnessTest() {
+		HistoryManager historyManager = new HistoryManager();
+
+		OfferInfo offer1 = new OfferInfo(true, 0, 7, 100, baseTime.minus(4, ChronoUnit.HOURS), 1, GrandExchangeOfferState.BUYING);
+
+		//buy 7 of an item 4 hours ago
+		historyManager.updateHistory(offer1);
+		assertEquals(7, historyManager.getItemsBoughtThisLimitWindow());
+		assertEquals(offer1.getTime().plus(4, ChronoUnit.HOURS), historyManager.getNextGeLimitRefresh());
+
+		//buy another 3 of that item 3 hours ago, so the amount you bought before the ge limit has refreshed is now 10
+		OfferInfo offer2 = new OfferInfo(true, 0, 10, 100, baseTime.minus(3, ChronoUnit.HOURS), 1, GrandExchangeOfferState.BOUGHT);
+		historyManager.updateHistory(offer2);
+		assertEquals(10, historyManager.getItemsBoughtThisLimitWindow());
+		assertEquals(offer1.getTime().plus(4, ChronoUnit.HOURS), historyManager.getNextGeLimitRefresh());
+
+		//buy another 1 of that item, but 1 minute in the future, so more than 4 hours from the first purchase of the item. By this time, the ge limit has reset
+		//so the amount you bought after the last ge refresh is 1.
+		OfferInfo offer3 = new OfferInfo(true, 0, 1, 100, baseTime.plus(1, ChronoUnit.MINUTES), 1, GrandExchangeOfferState.BUYING);
+		historyManager.updateHistory(offer3);
+		assertEquals(1, historyManager.getItemsBoughtThisLimitWindow());
+		assertEquals(offer3.getTime().plus(4, ChronoUnit.HOURS), historyManager.getNextGeLimitRefresh());
+
+
+
+
+	}
+
 }

--- a/src/test/java/com/flippingutilities/HistoryManagerTest.java
+++ b/src/test/java/com/flippingutilities/HistoryManagerTest.java
@@ -45,8 +45,6 @@ public class HistoryManagerTest
 		{
 			historyManager.updateHistory(offer);
 		}
-
-
 	}
 
 	@Test

--- a/src/test/java/com/flippingutilities/HistoryManagerTest.java
+++ b/src/test/java/com/flippingutilities/HistoryManagerTest.java
@@ -1,0 +1,9 @@
+package com.flippingutilities;
+
+
+import org.junit.Test;
+
+
+public class HistoryManagerTest
+{
+}

--- a/src/test/java/com/flippingutilities/HistoryManagerTest.java
+++ b/src/test/java/com/flippingutilities/HistoryManagerTest.java
@@ -2,7 +2,6 @@ package com.flippingutilities;
 
 
 import java.time.Instant;
-import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
@@ -18,7 +17,8 @@ public class HistoryManagerTest
 	private static Instant baseTime = Instant.now();
 
 	@BeforeClass
-	public static void setUp() {
+	public static void setUp()
+	{
 		List<OfferInfo> offers = new ArrayList<>();
 		//overall bought 24+3+20=47
 		//overall sold 7 + 3 + 30 = 40
@@ -41,7 +41,8 @@ public class HistoryManagerTest
 		offers.add(new OfferInfo(false, 0, 30, 105, baseTime.minus(4, ChronoUnit.MINUTES), 1, GrandExchangeOfferState.SOLD));
 
 		historyManager = new HistoryManager();
-		for (OfferInfo offer: offers) {
+		for (OfferInfo offer : offers)
+		{
 			historyManager.updateHistory(offer);
 		}
 
@@ -49,7 +50,8 @@ public class HistoryManagerTest
 	}
 
 	@Test
-	public void offersAreCorrectlyStandardizedTest() {
+	public void offersAreCorrectlyStandardizedTest()
+	{
 		List<OfferInfo> standardizedOffers = new ArrayList<>();
 		standardizedOffers.add(new OfferInfo(true, 0, 7, 100, baseTime.minus(40, ChronoUnit.MINUTES), 1, GrandExchangeOfferState.BUYING));
 		standardizedOffers.add(new OfferInfo(true, 0, 6, 100, baseTime.minus(30, ChronoUnit.MINUTES), 1, GrandExchangeOfferState.BUYING));
@@ -73,16 +75,18 @@ public class HistoryManagerTest
 	}
 
 	@Test
-	public void getProfitCorrectnessTest() {
+	public void getProfitCorrectnessTest()
+	{
 		assertEquals(200, historyManager.currentProfit(baseTime.minus(1, ChronoUnit.HOURS)));
 		historyManager.updateHistory(new OfferInfo(false, 0, 5, 105, baseTime.minus(4, ChronoUnit.MINUTES), 1, GrandExchangeOfferState.SOLD));
-		assertEquals(34*5, historyManager.currentProfit(baseTime.minus(25, ChronoUnit.MINUTES))); //34 buys and 40 sells, so looks for 34 items and profit is 5 gp ea.
+		assertEquals(34 * 5, historyManager.currentProfit(baseTime.minus(25, ChronoUnit.MINUTES))); //34 buys and 40 sells, so looks for 34 items and profit is 5 gp ea.
 		assertEquals(0, historyManager.currentProfit(baseTime));
 
 	}
 
 	@Test
-	public void gePropertiesCorrectnessTest() {
+	public void gePropertiesCorrectnessTest()
+	{
 		HistoryManager historyManager = new HistoryManager();
 
 		OfferInfo offer1 = new OfferInfo(true, 0, 7, 100, baseTime.minus(4, ChronoUnit.HOURS), 1, GrandExchangeOfferState.BUYING);
@@ -104,8 +108,6 @@ public class HistoryManagerTest
 		historyManager.updateHistory(offer3);
 		assertEquals(1, historyManager.getItemsBoughtThisLimitWindow());
 		assertEquals(offer3.getTime().plus(4, ChronoUnit.HOURS), historyManager.getNextGeLimitRefresh());
-
-
 
 
 	}

--- a/src/test/java/com/flippingutilities/TestRunner.java
+++ b/src/test/java/com/flippingutilities/TestRunner.java
@@ -1,0 +1,16 @@
+package com.flippingutilities;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+/**
+ * This class is responsible for running each test class so you don't have to run each file manually,
+ * just add your test class below, inside @Suite.SuiteClasses({}).
+ */
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+	HistoryManagerTest.class
+})
+public class TestRunner {
+
+}


### PR DESCRIPTION
### Purpose of this PR:

1. To delegate responsibility for various history related tasks (determining when ge limit will refresh to the HistoryManager
2. To provide realtime support for seeing how much a user can buy until the ge limit refreshes
3. To fix the previous algorithm used for determining when the ge limit refreshes and how many items a user could buy until the ge limit refreshes.

A quick note: I haven't made FlippingItem call get the info from HistoryManager yet for when the ge limit will refresh and the remaining limit. It's still using the old code. I'll submit another PR for that soon.

### Changes:

**enabling realtime and accurate querying for how many items you can buy until the GE limit refreshes and when the GE limit will refresh:**

These two pieces of information are available at the HistoryManager:
```
        @Getter
	private Instant nextGeLimitRefresh;

 	//the number of items bought since the last ge limit reset.
	@Getter
	private int itemsBoughtThisLimitWindow;
```

**The algorithm:**
Its very simple:

As events are received, ```HistoryManager.updateHistory(offer)``` is invoked:

```
public void updateHistory(OfferInfo newOffer)
	{
		storeStandardizedOffer(newOffer);
		updateGeProperties();

	}
```

```storeStandardizedOffer``` was discussed in #15 It just standardizes every incoming offer and adds them to the standardizedOffers list.




```updateGeProperties``` looks at the last item In the  standardizedOfferList (the most recent offer). Then, if its the first offer for that item, in which case nextGeLimitRefresh is null, it sets when the next ge limit refresh will be based on the time of that first offer and records the quantity in ```itemsBoughtThisLimitWindow```. Then, when another offer comes in and this method is invoked again it checks if the new offer is before the next ge limit refresh as set by the previous offer. If it is before the refresh, then it adds the quantity of the offer to the amount you have bought, as the refresh time hasn't been hit yet so the buys accumulate. If it is after the refresh, it sets the next GE limit refresh to be four hours plus the time of the offer it just got and sets the amount bought to the quantity of the offer as the limit has been refreshed and previous buys don't matter.

code for updateGeProperties:
```
private void updateGeProperties()
	{
		OfferInfo mostRecentOffer = standardizedOffers.get(standardizedOffers.size() - 1);
		if (!mostRecentOffer.isBuy())
		{
			return;
		}
		// when the time of the last offer (most recent offer) is greater than nextGeLimitRefresh,
		// you know the ge limits have refreshed. Since this is the first offer after the ge limits
		// have refreshed, the next refresh will be four hours after this offer's buy time.
		if (nextGeLimitRefresh == null || mostRecentOffer.getTime().compareTo(nextGeLimitRefresh) > 0)
		{
			nextGeLimitRefresh = mostRecentOffer.getTime().plus(4, ChronoUnit.HOURS);
			itemsBoughtThisLimitWindow = mostRecentOffer.getQuantity();
		}
		//if the last offer (most recent offer) is before the next ge limit refresh, add its quantity to the
		//amount bought this limit window.
		else
		{
			itemsBoughtThisLimitWindow += mostRecentOffer.getQuantity();
		}

	}
```

**An example:**

at time 1, you buy 2 lobsters. 
```
if (nextGeLimitRefresh == null || mostRecentOffer.getTime().compareTo(nextGeLimitRefresh) > 0)
```
This is your first offer of lobsters, so nextGeLimitRefresh is null. So,
nextGeLimitRefresh = 1+4 = 5 (it time 5, the ge limit will refresh)
itemsBoughtThisLimitWindow = 2

at time 2, you buy 30 lobsters.
```
if (nextGeLimitRefresh == null || mostRecentOffer.getTime().compareTo(nextGeLimitRefresh) > 0)
```
this will **not** be true as mostRecentOffer's time is not after nextGeLimitRefresh, which is at time 5.
Instead, the quantity of the offer will be added to the accumulated quantity thus far:

```
else
	{
		itemsBoughtThisLimitWindow += mostRecentOffer.getQuantity();
	}
```

Then at time 6, you buy 2 lobsters.

This is after the GE limit refresh (5), so everything should be reset. 
You have bought 2 lobsters since the last limit refresh and the next refresh is going to be four hours from this offer's time. So,
```
if (nextGeLimitRefresh == null || lastOffer.getTime().compareTo(nextGeLimitRefresh) > 0)
	{
		nextGeLimitRefresh = lastOffer.getTime().plus(4, ChronoUnit.HOURS);
		itemsBoughtThisLimitWindow = lastOffer.getQuantity();
	}
```

This process will be repeated every time a new offer comes in. 

### potential bug with the previous algorithm for checking GE limit refresh time and remaining GE limit

Previous algorithm:
```
public void updateGELimitReset()
	{
		if (tradeHistory != null)
		{
			OfferInfo oldestTrade = null;
			remainingGELimit = totalGELimit;

			//Check for the oldest trade within the last 4 hours.
			for (OfferInfo trade : tradeHistory)
			{
				if (trade.isBuy() && trade.getTime().getEpochSecond() >= Instant.now().minusSeconds(GE_RESET_TIME_SECONDS).getEpochSecond())
				{
					//Check if trade is older than oldest trade.
					if (oldestTrade == null || oldestTrade.getTime().getEpochSecond() > trade.getTime().getEpochSecond())
					{
						oldestTrade = trade;
					}
					remainingGELimit -= trade.getQuantity();
				}
			}

			//No buy trade found in the last 4 hours.
			if (oldestTrade == null)
			{
				remainingGELimit = totalGELimit;
				geLimitResetTime = null;
			}
			else
			{
				geLimitResetTime = oldestTrade.getTime().plusSeconds(GE_RESET_TIME_SECONDS);
			}

		}
		else
		{
			//No previous trade history; assume no trades made.
			geLimitResetTime = null;
			remainingGELimit = totalGELimit;
		}
	}
```

This algorithm looks at every buy offer in the past 4 hours and subtracts the quantity from the limit to get the items left to buy. And it looks for the oldest trade within those last 4 hours to see when the next ge limit refresh will be. 

**It can return inaccurate results in certain edge cases.**

**An example:**
Let's say it is time 10 currently.  You call this method and this method looks at a time window from 
time 6 to time 10 (now). It sees several offers like so:
```
a BOUGHT offer for 3 lobster at time 6.5 
a BOUGHT offer for 5 lobster at time 7
```
The method considers the offer at time 6.5 the oldest offer and does
```geLimitResetTime = oldestTrade.getTime().plusSeconds(GE_RESET_TIME_SECONDS);```

and sets the geLimitResetTime to 6.5 +4 = 10.5
and the remainingGeLimit will be LOBSTER_LIMIT - (3+5).

**This can be incorrect**:
The general case in which this algorithm is incorrect is when a user has bought the item prior to the 4 hour window.

**what happens if the user actually started buying lobster at time 5, but because only the last 4 hours were looked at, those offers aren't calculated in?**

Perhaps the full offers list looks like:

```
a BOUGHT offer for 6 lobster at time 5
a BOUGHT offer for 3 lobster at time 6.5 
a BOUGHT offer for 5 lobster at time 7
```

the real geLimitReset time is 5 + 4 = 9 (user bought their first lobster at time 5)
and the real remainingGeLimit is just LOBSTER_LIMIT, as the refresh time has already been passed.

However, the algorithm would say 

geLimitResetTime is 6.5 +4 = 10.5
and the remainingGeLimit will be LOBSTER_LIMIT - (3+5).

as it has screened out the first offer due to it not being in the four window.


### Other relevant changes:

Removed a check from isBadEvent because it was screening out events at login which are needed. Ex: You put in an offer, log off, it completes while you are offline, and then when you log back in you get that event. If we don't get that event, we lose info on how to update the limit in accordance with that offer, etc.

Made OfferInfo stop extending GrandExchangeTrade as it was messy and didn't help much. The api of an OfferInfo and a GrandExchangeTrade is the exact same, so I only had to change method signatures of methods that previously accepted a GrandExchangeTrade to now accept an OfferInfo.

Made OfferInfo have a AllArgsConstructor, so you create one through the constructor instead of a blank constructor and then calling a bunch of setters which I realized was very painful when constructing many OfferInfo objects in the tests :D 

Added a test class for HistoryManager and tested its functionality.

Added a TestRunner class where all the tests are. This simply runs all the test classes so that you don't have to run each one manually.


### Interesting Stuff:

On login, if you have completed offers, you will receive an event for them, EVERY login. So, if you logged in, got the event, then logged out, then logged back in, you will get the same events. The events de duplicator (isBadEvent) should deal with that though.


Also, the search bar is really slick :D 

