### PR TITLE
Hooked in History manager to the event pipeline, realtime profit, ge limit tracking, and limit refresh time tracking now works :)

### DIFF
--- a/src/main/java/com/flippingutilities/FlippingItem.java
+++ b/src/main/java/com/flippingutilities/FlippingItem.java
@@ -67,17 +67,16 @@ public class FlippingItem
 
 	@Getter
 	@Setter
-	private boolean isFrozen;
+	private boolean isFrozen = false;
 
 	private HistoryManager history = new HistoryManager();
 
 
-	public FlippingItem(int itemId, String itemName, int totalGeLimit, boolean isFrozen)
+	public FlippingItem(int itemId, String itemName, int totalGeLimit)
 	{
 		this.itemId = itemId;
 		this.itemName = itemName;
 		this.totalGELimit = totalGeLimit;
-		this.isFrozen = isFrozen;
 	}
 
 

--- a/src/main/java/com/flippingutilities/FlippingItem.java
+++ b/src/main/java/com/flippingutilities/FlippingItem.java
@@ -27,7 +27,6 @@
 package com.flippingutilities;
 
 import java.time.Instant;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -43,7 +42,6 @@ import lombok.extern.slf4j.Slf4j;
  * of a panel which is then displayed.
  */
 @Slf4j
-@AllArgsConstructor
 public class FlippingItem
 {
 	@Getter
@@ -68,13 +66,20 @@ public class FlippingItem
 	private Instant latestSellTime;
 
 	@Getter
-	private Instant geLimitResetTime;
-
-	@Getter
 	@Setter
 	private boolean isFrozen;
 
-	private HistoryManager history;
+	private HistoryManager history = new HistoryManager();
+
+
+	public FlippingItem(int itemId, String itemName, int totalGeLimit, boolean isFrozen)
+	{
+		this.itemId = itemId;
+		this.itemName = itemName;
+		this.totalGELimit = totalGeLimit;
+		this.isFrozen = isFrozen;
+	}
+
 
 	public void updateHistory(OfferInfo newOffer)
 	{
@@ -89,6 +94,11 @@ public class FlippingItem
 	public int remainingGeLimit()
 	{
 		return totalGELimit - history.getItemsBoughtThisLimitWindow();
+	}
+
+	public Instant getGeLimitResetTime()
+	{
+		return history.getNextGeLimitRefresh();
 	}
 
 	public void validateGeProperties()

--- a/src/main/java/com/flippingutilities/FlippingItem.java
+++ b/src/main/java/com/flippingutilities/FlippingItem.java
@@ -27,18 +27,25 @@
 package com.flippingutilities;
 
 import java.time.Instant;
-import java.util.ArrayList;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * This class is the representation of an item that a user is flipping. It contains information about the
+ * margin of the item (buying and selling price), the latest buy and sell times, and the history of the item
+ * which is all of the offers that make up the trade history of that item. This history is managed by the
+ * {@link HistoryManager} and is used to get the profits for this item, how many more of it you can buy
+ * until the ge limit refreshes, and when the next ge limit refreshes.
+ * <p>
+ * This class is the model behind a {@link FlippingItemPanel} as its data is used to create the contents
+ * of a panel which is then displayed.
+ */
 @Slf4j
 @AllArgsConstructor
 public class FlippingItem
 {
-	private static int GE_RESET_TIME_SECONDS = 60 * 60 * 4;
-
 	@Getter
 	private final int itemId;
 
@@ -84,16 +91,20 @@ public class FlippingItem
 		return totalGELimit - history.getItemsBoughtThisLimitWindow();
 	}
 
-	public void validateGeProperties() {
+	public void validateGeProperties()
+	{
 		history.validateGeProperties();
 	}
 
 	/**
-	 * This method is used to update the margin of an item. As such it is only envoked when an offer
+	 * This method is used to update the margin of an item. As such it is only invoked when an offer is a
+	 * margin check. It is invoked by {@link FlippingPlugin#updateFlippingItem} which itself is only
+	 * invoked when an offer is a margin check.
 	 *
 	 * @param newOffer the new offer just received.
 	 */
-	public void updateMargin(OfferInfo newOffer) {
+	public void updateMargin(OfferInfo newOffer)
+	{
 		boolean tradeBuyState = newOffer.isBuy();
 		int tradePrice = newOffer.getPrice();
 		Instant tradeTime = newOffer.getTime();

--- a/src/main/java/com/flippingutilities/FlippingItemPanel.java
+++ b/src/main/java/com/flippingutilities/FlippingItemPanel.java
@@ -123,7 +123,7 @@ public class FlippingItemPanel extends JPanel
 
 		final int itemID = flippingItem.getItemId();
 
-		updateProfits();
+		updatePotentialProfit();
 
 		setLayout(new BorderLayout());
 		setBackground(ColorScheme.DARKER_GRAY_COLOR);
@@ -327,7 +327,7 @@ public class FlippingItemPanel extends JPanel
 
 		int roiGradientMax = plugin.getConfig().roiGradientMax();
 
-		updateProfits();
+		updatePotentialProfit();
 		SwingUtilities.invokeLater(() ->
 		{
 			buyPriceVal
@@ -383,7 +383,7 @@ public class FlippingItemPanel extends JPanel
 	}
 
 	//Recalculates profits.
-	public void updateProfits()
+	public void updatePotentialProfit()
 	{
 		this.profitEach = sellPrice - buyPrice;
 
@@ -436,8 +436,7 @@ public class FlippingItemPanel extends JPanel
 			SwingUtilities.invokeLater(() ->
 			{
 				buyPriceVal.setForeground(OUTDATED_COLOR);
-				buyPriceVal
-					.setToolTipText("<html>" + OUTDATED_STRING + "<br>" + latestBuyString + "</html>");
+				buyPriceVal.setToolTipText("<html>" + OUTDATED_STRING + "<br>" + latestBuyString + "</html>");
 			});
 
 		}

--- a/src/main/java/com/flippingutilities/FlippingItemPanel.java
+++ b/src/main/java/com/flippingutilities/FlippingItemPanel.java
@@ -40,7 +40,6 @@ import java.time.format.DateTimeFormatter;
 import javax.swing.BorderFactory;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
-import javax.swing.JCheckBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.SwingConstants;
@@ -107,7 +106,6 @@ public class FlippingItemPanel extends JPanel
 	JLabel ROILabel = new JLabel();
 	JLabel arrowIcon = new JLabel(OPEN_ICON);
 	JButton clearButton = new JButton(DELETE_ICON);
-	JCheckBox marginFreezer = new JCheckBox();
 
 	/* Panels */
 	JPanel topPanel = new JPanel(new BorderLayout());
@@ -313,8 +311,8 @@ public class FlippingItemPanel extends JPanel
 		itemInfo.setBorder(ITEM_INFO_BORDER);
 
 		buildPanelValues();
-		updateGELimits();
-		checkOutdatedPriceTimes();
+		updateGePropertiesDisplay();
+		updatePriceOutdatedDisplay();
 
 		add(topPanel, BorderLayout.NORTH);
 		add(itemInfo, BorderLayout.CENTER);
@@ -394,8 +392,8 @@ public class FlippingItemPanel extends JPanel
 		the margin check loss. */
 		if (plugin.getConfig().geLimitProfit())
 		{
-			this.profitTotal = (flippingItem.getRemainingGELimit() == 0) ? 0
-				: flippingItem.getRemainingGELimit() * profitEach - (plugin.getConfig().marginCheckLoss()
+			this.profitTotal = (flippingItem.remainingGeLimit() == 0) ? 0
+				: flippingItem.remainingGeLimit() * profitEach - (plugin.getConfig().marginCheckLoss()
 				? profitEach : 0);
 		}
 		else
@@ -414,7 +412,7 @@ public class FlippingItemPanel extends JPanel
 	}
 
 	//Checks if prices are outdated and updates the tooltip.
-	public void checkOutdatedPriceTimes()
+	public void updatePriceOutdatedDisplay()
 	{
 		//Update time of latest price update.
 		Instant latestBuyTime = flippingItem.getLatestBuyTime();
@@ -520,18 +518,17 @@ public class FlippingItemPanel extends JPanel
 		return timeFormatter.format(time);
 	}
 
-	public void updateGELimits()
+	/**
+	 * uses the properties of the FlippingItem to set the ge limit and refresh time display.
+	 */
+	public void updateGePropertiesDisplay()
 	{
 		SwingUtilities.invokeLater(() ->
 		{
-			if (flippingItem.getGeLimitResetTime() != null && flippingItem.getGeLimitResetTime()
-				.isBefore(Instant.now()))
-			{
-				flippingItem.resetGELimit();
-			}
+			flippingItem.validateGeProperties();
 
 			limitLabel
-				.setText("GE limit: " + String.format(NUM_FORMAT, flippingItem.getRemainingGELimit()));
+				.setText("GE limit: " + String.format(NUM_FORMAT, flippingItem.remainingGeLimit()));
 			if (flippingItem.getGeLimitResetTime() == null)
 			{
 				limitLabel.setToolTipText("None has been bought in the past 4 hours.");

--- a/src/main/java/com/flippingutilities/FlippingPanel.java
+++ b/src/main/java/com/flippingutilities/FlippingPanel.java
@@ -36,6 +36,8 @@ import java.awt.GridBagLayout;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.image.BufferedImage;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
@@ -257,7 +259,8 @@ public class FlippingPanel extends PluginPanel
 					{
 						if (e.getButton() == MouseEvent.BUTTON1)
 						{
-							deletePanel(newPanel);
+							System.out.println(item.currentProfit(Instant.now().minus(4,ChronoUnit.HOURS)));
+							//deletePanel(newPanel);
 						}
 					}
 				});

--- a/src/main/java/com/flippingutilities/FlippingPanel.java
+++ b/src/main/java/com/flippingutilities/FlippingPanel.java
@@ -259,8 +259,7 @@ public class FlippingPanel extends PluginPanel
 					{
 						if (e.getButton() == MouseEvent.BUTTON1)
 						{
-							System.out.println(item.currentProfit(Instant.now().minus(4,ChronoUnit.HOURS)));
-							//deletePanel(newPanel);
+							deletePanel(newPanel);
 						}
 					}
 				});

--- a/src/main/java/com/flippingutilities/FlippingPanel.java
+++ b/src/main/java/com/flippingutilities/FlippingPanel.java
@@ -346,21 +346,22 @@ public class FlippingPanel extends PluginPanel
 	}
 
 	//Updates tooltips on prices to show how long ago the latest margin check was.
-	public void updateTimes()
+
+	public void updateActivePanelsPriceOutdatedDisplay()
 	{
 		for (FlippingItemPanel activePanel : activePanels)
 		{
-			activePanel.checkOutdatedPriceTimes();
+			activePanel.updatePriceOutdatedDisplay();
 		}
 	}
 
-	public void updateGELimit()
+	public void updateActivePanelsGePropertiesDisplay()
 	{
 		SwingUtilities.invokeLater(() ->
 		{
 			for (FlippingItemPanel activePanel : activePanels)
 			{
-				activePanel.updateGELimits();
+				activePanel.updateGePropertiesDisplay();
 			}
 		});
 	}

--- a/src/main/java/com/flippingutilities/FlippingPlugin.java
+++ b/src/main/java/com/flippingutilities/FlippingPlugin.java
@@ -383,7 +383,7 @@ public class FlippingPlugin extends Plugin
 		ItemStats itemStats = itemManager.getItemStats(tradeItemId, false);
 		int geLimit = itemStats != null ? itemStats.getGeLimit() : 0;
 
-		FlippingItem flippingItem = new FlippingItem(tradeItemId, itemName, geLimit, false);
+		FlippingItem flippingItem = new FlippingItem(tradeItemId, itemName, geLimit);
 		flippingItem.updateMargin(newOffer);
 		flippingItem.updateHistory(newOffer);
 

--- a/src/main/java/com/flippingutilities/FlippingPlugin.java
+++ b/src/main/java/com/flippingutilities/FlippingPlugin.java
@@ -33,13 +33,11 @@ import java.lang.reflect.Type;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.swing.SwingUtilities;
 import lombok.Getter;
@@ -229,14 +227,16 @@ public class FlippingPlugin extends Plugin
 	/**
 	 * This method is invoked every time the plugin receives a GrandExchangeOfferChanged event.
 	 * The events are handled in one of two ways:
-	 *
+	 * <p>
 	 * if the offer is deemed a margin check, its either added
 	 * to the tradesList (if it doesn't exist), or, if the item exists, it is updated to reflect the margins as
 	 * discovered by the margin check.
-	 *
+	 * <p>
 	 * The second way events are handled is in all other cases except for margin checks. If an offer is
 	 * not a margin check and the offer exists, you don't need to update the margins of the item, but you do need
 	 * to update its history (which updates its ge limit/reset time and the profit a user made for that item.
+	 * <p>
+	 * The history of a flipping item is updated in every branch of this method.
 	 *
 	 * @param newOfferEvent the offer event that represents when an offer is updated
 	 *                      (buying, selling, bought, sold, cancelled sell, or cancelled buy)
@@ -256,7 +256,7 @@ public class FlippingPlugin extends Plugin
 		{
 			if (flippingItem.isPresent())
 			{
-				updateFlip(flippingItem.get(), newOffer);
+				updateFlippingItem(flippingItem.get(), newOffer);
 				tradesList.remove(flippingItem.get());
 				tradesList.add(0, flippingItem.get());
 			}
@@ -414,7 +414,7 @@ public class FlippingPlugin extends Plugin
 	 * @param flippingItem flippingItem that is being updated.
 	 * @param newOffer     the offer that just came in.
 	 */
-	private void updateFlip(FlippingItem flippingItem, OfferInfo newOffer)
+	private void updateFlippingItem(FlippingItem flippingItem, OfferInfo newOffer)
 	{
 		flippingItem.updateMargin(newOffer);
 		flippingItem.updateHistory(newOffer);

--- a/src/main/java/com/flippingutilities/FlippingPlugin.java
+++ b/src/main/java/com/flippingutilities/FlippingPlugin.java
@@ -383,24 +383,8 @@ public class FlippingPlugin extends Plugin
 		ItemStats itemStats = itemManager.getItemStats(tradeItemId, false);
 		int geLimit = itemStats != null ? itemStats.getGeLimit() : 0;
 
-		int tradeBuyPrice = 0;
-		int tradeSellPrice = 0;
-
-		Instant tradeBuyTime = null;
-		Instant tradeSellTime = null;
-
-		if (newOffer.getQuantity() == 1)
-		{
-			tradeBuyPrice = !newOffer.isBuy() ? newOffer.getPrice() : 0;
-			tradeSellPrice = newOffer.isBuy() ? newOffer.getPrice() : 0;
-
-			tradeBuyTime = !newOffer.isBuy() ? newOffer.getTime() : null;
-			tradeSellTime = newOffer.isBuy() ? newOffer.getTime() : null;
-		}
-
-		FlippingItem flippingItem = new FlippingItem(tradeItemId, itemName, geLimit,
-			tradeBuyPrice, tradeSellPrice, tradeBuyTime, tradeSellTime, null, false, new HistoryManager());
-
+		FlippingItem flippingItem = new FlippingItem(tradeItemId, itemName, geLimit, false);
+		flippingItem.updateMargin(newOffer);
 		flippingItem.updateHistory(newOffer);
 
 		tradesList.add(0, flippingItem);

--- a/src/main/java/com/flippingutilities/FlippingPlugin.java
+++ b/src/main/java/com/flippingutilities/FlippingPlugin.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -166,7 +167,9 @@ public class FlippingPlugin extends Plugin
 				{
 					for (FlippingItem flippingItem : tradesList)
 					{
-						flippingItem.updateGELimitReset();
+						//it may have been four hours since the first time the user bought the item, so
+						//it might be displaying old values, so this is a way to clear them on start up.
+						flippingItem.validateGeProperties();
 					}
 					panel.rebuildFlippingPanel(tradesList);
 				}
@@ -177,8 +180,8 @@ public class FlippingPlugin extends Plugin
 		//Ensures the panel timers are updated at 10 times per second.
 		timeUpdateFuture = executor.scheduleAtFixedRate(() ->
 		{
-			panel.updateTimes();
-			updateGELimitRemaining();
+			panel.updateActivePanelsPriceOutdatedDisplay();
+			backgroundUpdateGePropertiesDisplay();
 		}, 100, 100, TimeUnit.MILLISECONDS);
 	}
 
@@ -224,6 +227,58 @@ public class FlippingPlugin extends Plugin
 	}
 
 	/**
+	 * This method is invoked every time the plugin receives a GrandExchangeOfferChanged event.
+	 * The events are handled in one of two ways:
+	 *
+	 * if the offer is deemed a margin check, its either added
+	 * to the tradesList (if it doesn't exist), or, if the item exists, it is updated to reflect the margins as
+	 * discovered by the margin check.
+	 *
+	 * The second way events are handled is in all other cases except for margin checks. If an offer is
+	 * not a margin check and the offer exists, you don't need to update the margins of the item, but you do need
+	 * to update its history (which updates its ge limit/reset time and the profit a user made for that item.
+	 *
+	 * @param newOfferEvent the offer event that represents when an offer is updated
+	 *                      (buying, selling, bought, sold, cancelled sell, or cancelled buy)
+	 */
+	@Subscribe
+	public void onGrandExchangeOfferChanged(GrandExchangeOfferChanged newOfferEvent)
+	{
+		if (isBadEvent(newOfferEvent))
+		{
+			return;
+		}
+
+		final OfferInfo newOffer = tradeConstructor(newOfferEvent);
+		Optional<FlippingItem> flippingItem = findItemInTradesList(newOffer.getItemId());
+
+		if (newOffer.isMarginCheck())
+		{
+			if (flippingItem.isPresent())
+			{
+				updateFlip(flippingItem.get(), newOffer);
+				tradesList.remove(flippingItem.get());
+				tradesList.add(0, flippingItem.get());
+			}
+			else
+			{
+				addToTradesList(newOffer);
+			}
+
+			panel.rebuildFlippingPanel(tradesList);
+		}
+
+		//if its not a margin check and the item isn't present, you don't know what to put as the buy/sell price
+		else if (flippingItem.isPresent())
+		{
+			flippingItem.get().updateHistory(newOffer);
+		}
+
+		updateConfig();
+		panel.updateActivePanelsGePropertiesDisplay();
+	}
+
+	/**
 	 * Runelite has some wonky events at times. For example, every buy/sell/cancelled buy/cancelled sell
 	 * spawns two identical events. And when you fully buy/sell item, it also spawns two events (a
 	 * buying/selling event and a bought/sold event). This screens out the unwanted events/duplicate
@@ -232,7 +287,7 @@ public class FlippingPlugin extends Plugin
 	 * @param newOfferEvent
 	 * @return a boolean representing whether the offer should be passed on or discarded
 	 */
-	public boolean isBadEvent(GrandExchangeOfferChanged newOfferEvent)
+	private boolean isBadEvent(GrandExchangeOfferChanged newOfferEvent)
 	{
 		GrandExchangeOffer newOffer = newOfferEvent.getOffer();
 		int newOfferSlot = newOfferEvent.getSlot();
@@ -281,37 +336,13 @@ public class FlippingPlugin extends Plugin
 		}
 	}
 
-	//When flipping via margin checking, we look for the lowest instant buy price
-	// to determine what our sell price should be to undercut existing offers, and vice versa for our buy price.
-	@Subscribe
-	public void onGrandExchangeOfferChanged(GrandExchangeOfferChanged newOfferEvent)
-	{
-		if (isBadEvent(newOfferEvent))
-		{
-			return;
-		}
-
-		final GrandExchangeOffer newOffer = newOfferEvent.getOffer();
-		final GrandExchangeOfferState newOfferState = newOffer.getState();
-
-		//Offer is a margin check.
-		//May change this in the future to be able to update prices independent of quantity.
-		//Perhaps some way of timing the state change from buying to bought such that we know it was "instantly" bought/sold?
-		if ((newOfferState == GrandExchangeOfferState.BOUGHT || newOfferState == GrandExchangeOfferState.SOLD) && newOffer.getQuantitySold() == 1)
-		{
-			addFlipTrade(tradeConstructor(newOfferEvent));
-			panel.rebuildFlippingPanel(tradesList);
-		}
-		//If the new offer is of state BOUGHT Record the trade to keep track of GE limit.
-		else if (newOffer.getQuantitySold() > 0 && newOfferState == GrandExchangeOfferState.BOUGHT)
-		{
-			addFlipTrade(tradeConstructor(newOfferEvent));
-		}
-
-		updateConfig();
-		panel.updateGELimit();
-	}
-
+	/**
+	 * This method extracts the data from the GrandExchangeOfferChanged event, which is a nested
+	 * data structure, and puts it into a flat data structure- OfferInfo. It also adds time to the offer.
+	 *
+	 * @param newOfferEvent new offer event just received
+	 * @return an OfferInfo with the relevant information.
+	 */
 	private OfferInfo tradeConstructor(GrandExchangeOfferChanged newOfferEvent)
 	{
 		GrandExchangeOffer offer = newOfferEvent.getOffer();
@@ -331,53 +362,26 @@ public class FlippingPlugin extends Plugin
 
 	}
 
-	//Adds GE trade data to the trades list.
-	public void addFlipTrade(OfferInfo trade)
+	private Optional<FlippingItem> findItemInTradesList(int itemIdToFind)
 	{
-		if (tradesList == null)
-		{
-			addToTradesList(trade);
-			return;
-		}
-		//Check if item is already present
-		final List<FlippingItem> matchingItem = tradesList.stream()
-			.filter((item) -> item.getItemId() == trade.getItemId())
-			.collect(Collectors.toList());
-
-		//No match found
-		if (matchingItem.size() == 0)
-		{
-			addToTradesList(trade);
-		}
-		else if (trade.getQuantity() == 1)
-		{
-			//Found a match, update the existing flipping item.
-			updateFlip(matchingItem.get(0), trade);
-
-			//Move item to top
-			tradesList.remove(matchingItem.get(0));
-			tradesList.add(0, matchingItem.get(0));
-		}
-		else
-		{
-			//Trade isn't a margin check, exclude updating prices.
-			matchingItem.get(0).addTradeHistory(trade);
-			matchingItem.get(0).updateGELimitReset();
-		}
+		return tradesList.stream().filter((item) -> item.getItemId() == itemIdToFind).findFirst();
 	}
 
-	//Constructs a FlippingItem and adds it to the tradeList.
-	private void addToTradesList(OfferInfo trade)
+
+	/**
+	 * Given a new offer, this method creates a FlippingItem, the data structure that represents an item
+	 * you are currently flipping, and adds it to the tradesList. The tradesList is a crucial part of the state
+	 * of the flippingPlugin, as only items from the tradesList are rendered and updated.
+	 *
+	 * @param newOffer new offer just received
+	 */
+	private void addToTradesList(OfferInfo newOffer)
 	{
-		int tradeItemId = trade.getItemId();
+		int tradeItemId = newOffer.getItemId();
 		String itemName = itemManager.getItemComposition(tradeItemId).getName();
 
 		ItemStats itemStats = itemManager.getItemStats(tradeItemId, false);
-		int tradeGELimit = itemStats != null ? itemStats.getGeLimit() : 0;
-		ArrayList<OfferInfo> tradeHistory = new ArrayList<OfferInfo>()
-		{{
-			add(trade);
-		}};
+		int geLimit = itemStats != null ? itemStats.getGeLimit() : 0;
 
 		int tradeBuyPrice = 0;
 		int tradeSellPrice = 0;
@@ -385,56 +389,35 @@ public class FlippingPlugin extends Plugin
 		Instant tradeBuyTime = null;
 		Instant tradeSellTime = null;
 
-		if (trade.getQuantity() == 1)
+		if (newOffer.getQuantity() == 1)
 		{
-			tradeBuyPrice = !trade.isBuy() ? trade.getPrice() : 0;
-			tradeSellPrice = trade.isBuy() ? trade.getPrice() : 0;
+			tradeBuyPrice = !newOffer.isBuy() ? newOffer.getPrice() : 0;
+			tradeSellPrice = newOffer.isBuy() ? newOffer.getPrice() : 0;
 
-			tradeBuyTime = !trade.isBuy() ? trade.getTime() : null;
-			tradeSellTime = trade.isBuy() ? trade.getTime() : null;
+			tradeBuyTime = !newOffer.isBuy() ? newOffer.getTime() : null;
+			tradeSellTime = newOffer.isBuy() ? newOffer.getTime() : null;
 		}
 
-		FlippingItem flippingItem = new FlippingItem(tradeHistory, tradeItemId, itemName, tradeGELimit, 0,
+		FlippingItem flippingItem = new FlippingItem(tradeItemId, itemName, geLimit,
 			tradeBuyPrice, tradeSellPrice, tradeBuyTime, tradeSellTime, null, false, new HistoryManager());
 
-		flippingItem.updateGELimitReset();
+		flippingItem.updateHistory(newOffer);
 
 		tradesList.add(0, flippingItem);
-
-		//Make sure we don't have too much data.
-		if (tradesList.size() > TRADES_LIST_MAX_SIZE)
-		{
-			tradesList.remove(tradesList.size() - 1);
-		}
 	}
 
-	//Updates the latest margins writes history for a Flipping Item
-	private void updateFlip(FlippingItem flippingItem, OfferInfo trade)
+	/**
+	 * This method updates a flipping item by adding to its history and updating its margins. Since it updates
+	 * the margins of an item, it is only envoked when the offer is a margin check. This method is called in
+	 * {@link FlippingPlugin#onGrandExchangeOfferChanged}
+	 *
+	 * @param flippingItem flippingItem that is being updated.
+	 * @param newOffer     the offer that just came in.
+	 */
+	private void updateFlip(FlippingItem flippingItem, OfferInfo newOffer)
 	{
-		boolean tradeBuyState = trade.isBuy();
-		int tradePrice = trade.getPrice();
-		Instant tradeTime = trade.getTime();
-
-		flippingItem.addTradeHistory(trade);
-		//Make sure the individual item objects aren't massive.
-		if (flippingItem.getTradeHistory().size() > TRADE_HISTORY_MAX_SIZE)
-		{
-			flippingItem.getTradeHistory().remove(flippingItem.getTradeHistory().size() - 1);
-		}
-		//Bought
-		if (!flippingItem.isFrozen())
-		{
-			if (tradeBuyState)
-			{
-				flippingItem.setLatestSellPrice(tradePrice);
-				flippingItem.setLatestSellTime(tradeTime);
-			}
-			else
-			{
-				flippingItem.setLatestBuyPrice(tradePrice);
-				flippingItem.setLatestBuyTime(tradeTime);
-			}
-		}
+		flippingItem.updateMargin(newOffer);
+		flippingItem.updateHistory(newOffer);
 
 		//When you have finished margin checking an item (when both the buy and sell prices have been set) and the auto
 		//freeze config option has been selected, freeze the item's margin.
@@ -443,7 +426,6 @@ public class FlippingPlugin extends Plugin
 			flippingItem.setFrozen(true);
 		}
 
-		flippingItem.updateGELimitReset();
 	}
 
 	@Provides
@@ -495,16 +477,16 @@ public class FlippingPlugin extends Plugin
 		panel.highlightItem(currentGEItemId);
 	}
 
-	private void updateGELimitRemaining()
+	/**
+	 * Called from scheduler and updates all of the active panel's ge properties display.
+	 */
+	private void backgroundUpdateGePropertiesDisplay()
 	{
 		long unitTime = Instant.now().toEpochMilli() / 100;
 
 		if (unitTime % 50 == 0)
 		{
-			for (FlippingItem flippingItem : tradesList)
-			{
-				panel.updateGELimit();
-			}
+			panel.updateActivePanelsGePropertiesDisplay();
 		}
 	}
 
@@ -621,7 +603,7 @@ public class FlippingPlugin extends Plugin
 				}
 				else
 				{
-					flippingWidget.showWidget("setQuantity", selectedItem.getRemainingGELimit());
+					flippingWidget.showWidget("setQuantity", selectedItem.remainingGeLimit());
 				}
 			}
 			else if (chatInputText.equals("Set a price for each item:"))

--- a/src/main/java/com/flippingutilities/HistoryManager.java
+++ b/src/main/java/com/flippingutilities/HistoryManager.java
@@ -212,4 +212,17 @@ public class HistoryManager
 		return moneySpent;
 	}
 
+	/**
+	 * This is to prevent old values from remaining for items that a user has bought and whose
+	 * refresh times have already passed. If the user buys the item again, the values will be up to date,
+	 * so this method wouldn't be needed, but there is no guarantee the user buys the item again after the
+	 * limit refreshes. This method should be called periodically to ensure no old values will remain.
+	 */
+	public void validateGeProperties() {
+		if (Instant.now().compareTo(nextGeLimitRefresh) >=0) {
+			nextGeLimitRefresh = null;
+			itemsBoughtThisLimitWindow = 0;
+		}
+	}
+
 }

--- a/src/main/java/com/flippingutilities/HistoryManager.java
+++ b/src/main/java/com/flippingutilities/HistoryManager.java
@@ -221,7 +221,7 @@ public class HistoryManager
 	 */
 	public void validateGeProperties()
 	{
-		if (Instant.now().compareTo(nextGeLimitRefresh) >= 0)
+		if (Instant.now().compareTo(nextGeLimitRefresh) >= 0 && !(nextGeLimitRefresh==null))
 		{
 			nextGeLimitRefresh = null;
 			itemsBoughtThisLimitWindow = 0;

--- a/src/main/java/com/flippingutilities/HistoryManager.java
+++ b/src/main/java/com/flippingutilities/HistoryManager.java
@@ -11,8 +11,9 @@ import lombok.Getter;
 import net.runelite.api.events.GrandExchangeOfferChanged;
 
 /**
- * manages the history for an item. This class is responsible for figuring out how much profit a user made for
- * an item.
+ * Manages the history for an item. This class is responsible for figuring out how much profit a user made for
+ * an item along with tracking how many items they bought since the last ge limit refresh and when the
+ * next ge limit refresh for this an item will be.
  */
 public class HistoryManager
 {
@@ -218,8 +219,10 @@ public class HistoryManager
 	 * so this method wouldn't be needed, but there is no guarantee the user buys the item again after the
 	 * limit refreshes. This method should be called periodically to ensure no old values will remain.
 	 */
-	public void validateGeProperties() {
-		if (Instant.now().compareTo(nextGeLimitRefresh) >=0) {
+	public void validateGeProperties()
+	{
+		if (Instant.now().compareTo(nextGeLimitRefresh) >= 0)
+		{
 			nextGeLimitRefresh = null;
 			itemsBoughtThisLimitWindow = 0;
 		}

--- a/src/main/java/com/flippingutilities/OfferInfo.java
+++ b/src/main/java/com/flippingutilities/OfferInfo.java
@@ -45,6 +45,17 @@ public class OfferInfo
 	}
 
 	/**
+	 * A margin check is defined as an offer that is either a BOUGHT or SOLD offer and has a quantity of 1. This
+	 * resembles the typical margin check process wherein you buy an item (quantity of 1) for a high press, and then
+	 * sell that item (quantity of 1), to figure out the optimal buying and selling prices.
+	 *
+	 * @return boolean value representing whether the offer is a margin check or not
+	 */
+	public boolean isMarginCheck() {
+		return (state == GrandExchangeOfferState.BOUGHT || state == GrandExchangeOfferState.SOLD) && quantity == 1;
+	}
+
+	/**
 	 * Returns an offerInfo object with the quantity sold/bought the amount of items sold/bought since
 	 * the last event, rather than current quantity sold/bought overall in the trade. This makes it
 	 * easier to calculate the profit.

--- a/src/main/java/com/flippingutilities/OfferInfo.java
+++ b/src/main/java/com/flippingutilities/OfferInfo.java
@@ -51,7 +51,8 @@ public class OfferInfo
 	 *
 	 * @return boolean value representing whether the offer is a margin check or not
 	 */
-	public boolean isMarginCheck() {
+	public boolean isMarginCheck()
+	{
 		return (state == GrandExchangeOfferState.BOUGHT || state == GrandExchangeOfferState.SOLD) && quantity == 1;
 	}
 


### PR DESCRIPTION
The previous pr #19, involved the creation of the HistoryManager and the reimplementation of some algorithms for tracking ge limits and refresh times. 

This pr concerns actually hooking up the HistoryManager to the current event flow. While hooking it up I realized that lots of things were actually simplified and so I refactored a bunch of stuff.

**There isn't too much to explain, but I'll list the changes:**

### FlippingItem changes:
1. removed the tradehistory arraylist from FlippingItem, as this role is now occupied by the HistoryManager
2. removed remainingGeLimit field from FlippingItem and instead put in a method that queries the HistoryManager for the number of items bought in the current limit window and then I subtract that from the total ge limit. This method is called remainingGeLimit.
3. Removed @allArgsConstructor from flippingItem and made a constructor that takes in only an itemId, item name, and a totalGeLimit. latestBuyPrice, latestSellPrice, latestSellTime, latestBuyTime, are now set by a method in FlippingItem called updateMargin.  This is so that it's easy to see that only way those variables are being set is through one method, instead of through the method and the constructor initialization. This also makes the code shorter as updateMargin replaced some of the code in addToTradesList in FlippingPlugin as it used to get the margin and then pass it in to the FlippingItem constructor. Now I simply init the FlippingItem and then call FlippingItem.updateMargin(newOffer).
4. removed addTradeHistory as this is now the HistoryManager's role.
5. Removed updateGeLimitReset and replaced it with validateGeProperties and getGeLimitResetTime. validateGeProperties makes a call to the HistoryManager's validateGeProperties method, which just checks if the ge properties(num items you bought in the current window and the next ge limit refresh time) are outdated and if so, it resets them to zero and null, respectively. ```getGeLimitResetTime``` queries the HistoryManager for the nextGeLimitRefresh.

**new FlippingItem API:** FlippingItem now has a simplified constructor and has the following methods:
 ```updateHistory(OfferInfo newOffer)``` which takes in a OfferInfo and calls ```HistoryManager.updateHistory```. This updates the history which in turn is used to return accurate profit and ge limit/next refresh.

```remainingGeLimit() ```, which returns the ```totalGeLimit - HistoryManager.getItemsBoughtThisLimitWindow()```.

```getGeLimitResetTime()```, which returns the next time the ge limit will refresh by querying the HistoryManager like ```HistoryManager.getNextGeLimitRefresh()```.

```validateGeProperties()```, which calls HistoryManager.validateGeProperties(), which then resets ```nextGeLimitRefresh``` and ```itemsBoughtThisLimitWindow``` if the nextGeLimitRefresh has been passed.
(nextGeLimitRefresh and itemsBoughtThisLimitWindow are variables that are accessed by getters in ```remainingGeLimit()``` and ```getGeLimitResetTime()```

```updateMargin(OfferInfo newOffer)```, which takes in a new offer and updates the FlippingItems latestBuyPrice or latestSellPrice, and the latestSellTime or the latestBuyTime. As such, this is only invoked when an offer is a margin check.

```currentProfit(Instant earliestTime)```, which queries the HistoryManager and returns the current profit for that item.


### FlippingItemPanel changes:

not much here, just renamed some method names as I was trying to establish a clear difference between methods that updated the display and methods that actually changed the underlying data, as there were some methods that updated the display that sounded like they were doing the work of methods in FlippingItem.

1. renamed updateProfits to updatePotentialProfits, to differentiate it with the profit calculating logic of the HistoryManager, as potential profit Is just determined by margin*buy limit, which is different than actual profit as calculated by the HistoryManager.
2.  renamed updateGeLimits() to updateGePropertiesDisplay(), to make it clear that it only updates the display and doesn't change any state in the underlying FlippingItem.
3. renamed  checkOutdatedPriceTimes() to updatePriceOutdatedDisplay(), to make it clear that it only updates the display.

### FlippingPanel changes:

1.  renamed updateGELimit() to updateActivePanelsGePropertiesDisplay(), which is a mouthful so I'm open to changing It LOL. Once again though, I wanted to make it clear that this was a method that didn't change state at all.
2. Since I renamed method in FlippingItemPanel, I had to call them in the FlippingPanel by their renamed names, so I did.
3. changed updateTimes() to updateActivePanelsPriceOutdatedDisplay(), for the same reasons. I'm open to a shorter name once again.

### HistoryManager changes:
1. added validateGeProperties(), its discussed above, just checks if the refresh time is outdated, and if so, it resets it.
2. Some comments

### OfferInfo changes:
1. added a method called isMarginCheck, that determines whether this OfferInfo object is a margin check. Its cleaner than doing it on the outside and delegates responsibility to the OfferInfo class which is more appropriate cause its inspecting its own variables now.

### FlippingPlugin changes:
1. changed updateGELimitRemaining() to backgroundUpdateGePropertiesDisplay(), to make it clear that this is something that runs in the background constantly, and that it doesn't affect state, only the display.
2. made onGrandExchangeOfferChanged() a lot simpler. There are less branches to go through and each branch calls a distinct method.
3. made addToTradesList() a lot simpler. It just creates the new FlippingItem, calls FlippingItem.updateHistory(newOffer) and FlippingItem.updateMargin(newOffer) and adds it to the tradesList and thats it.
4. created updateFlippingItem(FlippingItem item, OfferInfo newOffer) which simply updates updates a FlippingItem using FlippingItem.updateHistory(newOffer) and FlippingItem.updateMargin(newOffer). This method also checks if the FlippingItem should be frozen according to the auto freeze config option.


That's it :)
I've been using it and it works

