### PR TITLE
auto freeze waits until both the buy and sell price have been updated

### DIFF
--- a/src/main/java/com/flippingutilities/FlippingItem.java
+++ b/src/main/java/com/flippingutilities/FlippingItem.java
@@ -69,6 +69,12 @@ public class FlippingItem
 	@Setter
 	private boolean isFrozen = false;
 
+	@Getter
+	private boolean sellPriceNeedsUpdate = true;
+
+	@Getter
+	private boolean buyPriceNeedsUpdate = true;
+
 	private HistoryManager history = new HistoryManager();
 
 
@@ -118,19 +124,43 @@ public class FlippingItem
 		int tradePrice = newOffer.getPrice();
 		Instant tradeTime = newOffer.getTime();
 
-		if (!isFrozen())
+		if (!(isFrozen))
 		{
 			if (tradeBuyState)
 			{
 				latestSellPrice = tradePrice;
 				latestSellTime = tradeTime;
+				sellPriceNeedsUpdate = false;
 			}
 			else
 			{
 				latestBuyPrice = tradePrice;
 				latestBuyTime = tradeTime;
+				buyPriceNeedsUpdate = false;
 			}
 		}
 
+	}
+
+	/**
+	 * This Method is responsible for freezing an item. When an item is to be frozen, buyPriceNeedsUpdate and
+	 * sellPriceNeeds update are set to true, and isFrozen is set to false. isFrozen is set to false so that
+	 * updateMargin will update the margins and so that the components that rely on a FlippingItem can easily
+	 * see that it is frozen. BuyPriceNeedsUpdate and sellPriceNeedsUpdate are set to true, so that in
+	 * {@link FlippingPlugin#updateFlippingItem(FlippingItem, OfferInfo)} when an item is being updated, the margin
+	 * is only frozen again if BOTH the sell price and buy price are updated.
+	 * @param freeze
+	 */
+	public void freezeItem(boolean freeze) {
+		if (freeze) {
+			isFrozen = true;
+			buyPriceNeedsUpdate = false;
+			sellPriceNeedsUpdate = false;
+		}
+		else {
+			isFrozen = false;
+			buyPriceNeedsUpdate = true;
+			sellPriceNeedsUpdate = true;
+		}
 	}
 }

--- a/src/main/java/com/flippingutilities/FlippingItemPanel.java
+++ b/src/main/java/com/flippingutilities/FlippingItemPanel.java
@@ -176,12 +176,12 @@ public class FlippingItemPanel extends JPanel
 				{
 					if (flippingItem.isFrozen())
 					{
-						flippingItem.setFrozen(false);
+						flippingItem.freezeItem(false);
 						itemName.setForeground(Color.WHITE);
 					}
 					else
 					{
-						flippingItem.setFrozen(true);
+						flippingItem.freezeItem(true);
 						itemName.setForeground(FROZEN_COLOR);
 					}
 				}

--- a/src/main/java/com/flippingutilities/FlippingPanel.java
+++ b/src/main/java/com/flippingutilities/FlippingPanel.java
@@ -39,7 +39,6 @@ import java.util.ArrayList;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import javax.inject.Inject;
 import javax.swing.BorderFactory;
 import javax.swing.ImageIcon;
 import javax.swing.JLabel;
@@ -100,7 +99,6 @@ public class FlippingPanel extends JPanel
 	//Keeps track of all items currently displayed on the panel.
 	private ArrayList<FlippingItemPanel> activePanels = new ArrayList<>();
 
-	@Inject
 	public FlippingPanel(final FlippingPlugin plugin, final ItemManager itemManager, ScheduledExecutorService executor)
 	{
 		super(false);

--- a/src/main/java/com/flippingutilities/FlippingPlugin.java
+++ b/src/main/java/com/flippingutilities/FlippingPlugin.java
@@ -135,6 +135,7 @@ public class FlippingPlugin extends Plugin
 	protected void startUp()
 	{
 		//Main visuals.
+
 		flippingPanel = new FlippingPanel(this, itemManager, executor);
 		statPanel = new StatisticsPanel(this, itemManager, executor);
 
@@ -410,9 +411,9 @@ public class FlippingPlugin extends Plugin
 		flippingItem.updateMargin(newOffer);
 		flippingItem.updateHistory(newOffer);
 
-		//When you have finished margin checking an item (when both the buy and sell prices have been set) and the auto
+		//When you have finished margin checking an item (when both the buy and sell prices have been updated) and the auto
 		//freeze config option has been selected, freeze the item's margin.
-		if (!(flippingItem.getLatestBuyPrice() == 0) && !(flippingItem.getLatestSellPrice() == 0) && config.autoFreezeMargin())
+		if (!(flippingItem.isSellPriceNeedsUpdate()) && !(flippingItem.isBuyPriceNeedsUpdate()) && config.autoFreezeMargin())
 		{
 			flippingItem.setFrozen(true);
 		}

--- a/src/main/java/com/flippingutilities/HistoryManager.java
+++ b/src/main/java/com/flippingutilities/HistoryManager.java
@@ -221,7 +221,14 @@ public class HistoryManager
 	 */
 	public void validateGeProperties()
 	{
-		if (!(nextGeLimitRefresh == null) && Instant.now().compareTo(nextGeLimitRefresh) >= 0)
+
+		if (nextGeLimitRefresh == null)
+		{
+			return;
+		}
+
+		if (Instant.now().compareTo(nextGeLimitRefresh) >= 0)
+
 		{
 			nextGeLimitRefresh = null;
 			itemsBoughtThisLimitWindow = 0;


### PR DESCRIPTION
as per @telans suggestion, this PR makes it such that when you unfreeze an item, auto freeze waits until BOTH the buy and sell price have been updated.

To accomplish this I've added two variables to a FlippingItem, buyPriceNeedsUpdate and sellPriceNeedsUpdate. UpdateMargin() (in FlippingItem), sets these to variables to false if the item isn't currently frozen. FlippingPlugin, in ```updateFlippingItem()```, will only freeze an item if the config is set to auto freeze AND both buyPriceNeedsUpdate and sellPriceNeedsUpdate are false.

Right clicking the item name sets both those variables to either false or true along with changing the isFrozen variable.

I could've solved this also by resetting the FlippingItem's latestBuyPrice and latestSellPrice to 0 when an item was unfrozen, that way since the ```updateFlippingItem()``` in FlippingPlugin used to check whether latestBuyPrice AND latestSellPrice weren't ==0 to freeze an item, it would work as we wanted, but then it would destroy the price incase someone accidentally unfroze something. 


Also fixed validateGeProperties throwing a nullException as I thought the if statement was lazily evaluated (in ```if (!(nextGeLimitRefresh == null) && Instant.now().compareTo(nextGeLimitRefresh) >= 0)```, I assumed if nextGeLimitRefresh was null it would abandon the if statement instead of still trying to evaluate ```Instant.now().compareTo(nextGeLimitRefresh) >= 0)```, but it doesn't...