### PR TITLE
Preventing background updates from dying

### DIFF
--- a/src/main/java/com/flippingutilities/FlippingItemPanel.java
+++ b/src/main/java/com/flippingutilities/FlippingItemPanel.java
@@ -411,7 +411,12 @@ public class FlippingItemPanel extends JPanel
 		return Math.abs((float) profitEach / buyPrice * 100);
 	}
 
-	//Checks if prices are outdated and updates the tooltip.
+	/**
+	 * Checks if a FlippingItem's margins (buy and sell price) are outdated and updates the tooltip.
+	 * This is called in two places:
+	 * On initialization of a FlippingItemPanel and in FlippingPlugin by the scheduler which call its
+	 * every second.
+	 */
 	public void updatePriceOutdatedDisplay()
 	{
 		//Update time of latest price update.
@@ -519,6 +524,10 @@ public class FlippingItemPanel extends JPanel
 
 	/**
 	 * uses the properties of the FlippingItem to show the ge limit and refresh time display.
+	 * Places where this is called:
+	 * on initialization of a FlippingItemPanel
+	 * In {@link FlippingPanel#updateActivePanelsGePropertiesDisplay} which itself is envoked in two places in
+	 * the FlippingPlugin, a background thread, and every time an offer comes in.
 	 */
 	public void updateGePropertiesDisplay()
 	{

--- a/src/main/java/com/flippingutilities/FlippingItemPanel.java
+++ b/src/main/java/com/flippingutilities/FlippingItemPanel.java
@@ -518,7 +518,7 @@ public class FlippingItemPanel extends JPanel
 	}
 
 	/**
-	 * uses the properties of the FlippingItem to set the ge limit and refresh time display.
+	 * uses the properties of the FlippingItem to show the ge limit and refresh time display.
 	 */
 	public void updateGePropertiesDisplay()
 	{

--- a/src/main/java/com/flippingutilities/FlippingPanel.java
+++ b/src/main/java/com/flippingutilities/FlippingPanel.java
@@ -334,7 +334,7 @@ public class FlippingPanel extends JPanel
 
 	/**
 	 * Checks if a FlippingItem's margins (buy and sell price) are outdated and updates the tooltip.
-	 * This method is called in FlippingPLugin every second.
+	 * This method is called in FlippingPLugin every second by the scheduler.
 	 */
 	public void updateActivePanelsPriceOutdatedDisplay()
 	{

--- a/src/main/java/com/flippingutilities/FlippingPanel.java
+++ b/src/main/java/com/flippingutilities/FlippingPanel.java
@@ -340,6 +340,11 @@ public class FlippingPanel extends JPanel
 		}
 	}
 
+	/**
+	 * uses the properties of the FlippingItem to show the ge limit and refresh time display. This is envoked
+	 * in the FlippingPlugin in two places: Everytime an offer comes in (in onGrandExchangeOfferChanged) and
+	 * in a background thread every second, as initiated in the startUp() method of the FlippingPlugin.
+	 */
 	public void updateActivePanelsGePropertiesDisplay()
 	{
 		SwingUtilities.invokeLater(() ->

--- a/src/main/java/com/flippingutilities/FlippingPanel.java
+++ b/src/main/java/com/flippingutilities/FlippingPanel.java
@@ -332,6 +332,10 @@ public class FlippingPanel extends JPanel
 
 	//Updates tooltips on prices to show how long ago the latest margin check was.
 
+	/**
+	 * Checks if a FlippingItem's margins (buy and sell price) are outdated and updates the tooltip.
+	 * This method is called in FlippingPLugin every second.
+	 */
 	public void updateActivePanelsPriceOutdatedDisplay()
 	{
 		for (FlippingItemPanel activePanel : activePanels)

--- a/src/main/java/com/flippingutilities/FlippingPlugin.java
+++ b/src/main/java/com/flippingutilities/FlippingPlugin.java
@@ -187,7 +187,7 @@ public class FlippingPlugin extends Plugin
 		timeUpdateFuture = executor.scheduleAtFixedRate(() ->
 		{
 			flippingPanel.updateActivePanelsPriceOutdatedDisplay();
-			backgroundUpdateGePropertiesDisplay();
+			flippingPanel.updateActivePanelsGePropertiesDisplay();
 		}, 100, 1000, TimeUnit.MILLISECONDS);
 	}
 
@@ -468,16 +468,6 @@ public class FlippingPlugin extends Plugin
 		}
 		prevHighlight = currentGEItemId;
 		flippingPanel.highlightItem(currentGEItemId);
-	}
-
-	/**
-	 * Called from scheduler and updates all of the active panel's ge properties display.
-	 */
-	private void backgroundUpdateGePropertiesDisplay()
-	{
-
-		flippingPanel.updateActivePanelsGePropertiesDisplay();
-
 	}
 
 	//Functionality to the top right reset button.

--- a/src/main/java/com/flippingutilities/FlippingPlugin.java
+++ b/src/main/java/com/flippingutilities/FlippingPlugin.java
@@ -182,12 +182,13 @@ public class FlippingPlugin extends Plugin
 			return true;
 		});
 
-		//Ensures the panel timers are updated at 10 times per second.
+		//Ensures the panel displays for the margin check being outdated and the next ge refresh
+		//are updated every second.
 		timeUpdateFuture = executor.scheduleAtFixedRate(() ->
 		{
 			flippingPanel.updateActivePanelsPriceOutdatedDisplay();
 			backgroundUpdateGePropertiesDisplay();
-		}, 100, 100, TimeUnit.MILLISECONDS);
+		}, 100, 1000, TimeUnit.MILLISECONDS);
 	}
 
 	@Override
@@ -474,12 +475,9 @@ public class FlippingPlugin extends Plugin
 	 */
 	private void backgroundUpdateGePropertiesDisplay()
 	{
-		long unitTime = Instant.now().toEpochMilli() / 100;
 
-		if (unitTime % 50 == 0)
-		{
-			flippingPanel.updateActivePanelsGePropertiesDisplay();
-		}
+		flippingPanel.updateActivePanelsGePropertiesDisplay();
+
 	}
 
 	//Functionality to the top right reset button.


### PR DESCRIPTION
So I noticed that the two background updates would only work for a short period of time and then they would stop and STDOUT would be flooded with exceptions (though I haven't verified that these exceptions are related to the background updates dying).

I changed the executor to execute the tasks once every seconds instead of 10 times a second and it works. The background tasks haven't died yet and the ge limit display and the tooltip have been updating consistently ever since the change.

I also added some comments on the methods called in the background.

