### PR TITLE
Added functionality for freezing and unfreezing items (NON GUI)

### DIFF
--- a/src/main/java/com/flippingutilities/FlippingItem.java
+++ b/src/main/java/com/flippingutilities/FlippingItem.java
@@ -143,21 +143,25 @@ public class FlippingItem
 	}
 
 	/**
-	 * This Method is responsible for freezing an item. When an item is to be frozen, buyPriceNeedsUpdate and
+	 * This Method is responsible for freezing an item's margin. When an item is to be frozen, buyPriceNeedsUpdate and
 	 * sellPriceNeeds update are set to true, and isFrozen is set to false. isFrozen is set to false so that
 	 * updateMargin will update the margins and so that the components that rely on a FlippingItem can easily
 	 * see that it is frozen. BuyPriceNeedsUpdate and sellPriceNeedsUpdate are set to true, so that in
 	 * {@link FlippingPlugin#updateFlippingItem(FlippingItem, OfferInfo)} when an item is being updated, the margin
 	 * is only frozen again if BOTH the sell price and buy price are updated.
-	 * @param freeze
+	 *
+	 * @param freeze whether the item should have it's margin frozen or not
 	 */
-	public void freezeItem(boolean freeze) {
-		if (freeze) {
+	public void freezeMargin(boolean freeze)
+	{
+		if (freeze)
+		{
 			isFrozen = true;
 			buyPriceNeedsUpdate = false;
 			sellPriceNeedsUpdate = false;
 		}
-		else {
+		else
+		{
 			isFrozen = false;
 			buyPriceNeedsUpdate = true;
 			sellPriceNeedsUpdate = true;

--- a/src/main/java/com/flippingutilities/FlippingItemPanel.java
+++ b/src/main/java/com/flippingutilities/FlippingItemPanel.java
@@ -106,6 +106,7 @@ public class FlippingItemPanel extends JPanel
 	JLabel ROILabel = new JLabel();
 	JLabel arrowIcon = new JLabel(OPEN_ICON);
 	JButton clearButton = new JButton(DELETE_ICON);
+	JLabel itemName;
 
 	/* Panels */
 	JPanel topPanel = new JPanel(new BorderLayout());
@@ -160,7 +161,7 @@ public class FlippingItemPanel extends JPanel
 		itemClearPanel.add(clearButton, BorderLayout.EAST);
 
 		/* Item name panel */
-		JLabel itemName = new JLabel(flippingItem.getItemName(), SwingConstants.CENTER);
+		itemName = new JLabel(flippingItem.getItemName(), SwingConstants.CENTER);
 
 		itemName.setForeground(flippingItem.isFrozen() ? FROZEN_COLOR : Color.WHITE);
 		itemName.setFont(FontManager.getRunescapeBoldFont());
@@ -177,12 +178,12 @@ public class FlippingItemPanel extends JPanel
 				{
 					if (flippingItem.isFrozen())
 					{
-						flippingItem.freezeItem(false);
+						flippingItem.freezeMargin(false);
 						itemName.setForeground(Color.WHITE);
 					}
 					else
 					{
-						flippingItem.freezeItem(true);
+						flippingItem.freezeMargin(true);
 						itemName.setForeground(FROZEN_COLOR);
 					}
 				}
@@ -557,5 +558,18 @@ public class FlippingItemPanel extends JPanel
 					+ ".<html>");
 			}
 		});
+	}
+
+	/**
+	 * Freezes or unfreezes the margin display along with the margin of the underlying FlippingItem
+	 *
+	 * @param freeze whether the margin display and underlyingFlippingItem should be frozen
+	 *               or not.
+	 */
+	public void freezeMargin(boolean freeze)
+	{
+		flippingItem.freezeMargin(freeze);
+		itemName.setForeground(flippingItem.isFrozen() ? FROZEN_COLOR : Color.WHITE);
+
 	}
 }

--- a/src/main/java/com/flippingutilities/FlippingPanel.java
+++ b/src/main/java/com/flippingutilities/FlippingPanel.java
@@ -413,4 +413,17 @@ public class FlippingPanel extends JPanel
 		searchBar.setIcon(IconTextField.Icon.SEARCH);
 		rebuildFlippingPanel(result);
 	}
+
+	/**
+	 * Freezes or unfreezes all the activePanel's margin displays along with the underlying FlippingItem's margin
+	 *
+	 * @param freeze whether the panel/item should be frozen or not.
+	 */
+	private void freezeActivePanels(boolean freeze)
+	{
+		for (FlippingItemPanel panel : activePanels)
+		{
+			panel.freezeMargin(freeze);
+		}
+	}
 }


### PR DESCRIPTION
Added functionality for freezing and unfreezing items.

```freezeActivePanels``` in FlippingPanel will go through every active panel and call ```panel.freezeMargin```.

```freezeMargin```in FlippingItemPanel will set the background of the item name to the frozen color or the regular color and will freeze the underlying FlippingItem.


