### PR TITLE
added latest buy and sell times to flipping item to be queried later on

### DIFF
--- a/src/main/java/com/flippingutilities/FlippingPlugin.java
+++ b/src/main/java/com/flippingutilities/FlippingPlugin.java
@@ -283,7 +283,7 @@ public class FlippingPlugin extends Plugin
 		//if its not a margin check and the item isn't present, you don't know what to put as the buy/sell price
 		else if (flippingItem.isPresent())
 		{
-			flippingItem.get().updateHistory(newOffer);
+			flippingItem.get().update(newOffer);
 		}
 
 		updateConfig();
@@ -399,7 +399,7 @@ public class FlippingPlugin extends Plugin
 
 		FlippingItem flippingItem = new FlippingItem(tradeItemId, itemName, geLimit);
 		flippingItem.updateMargin(newOffer);
-		flippingItem.updateHistory(newOffer);
+		flippingItem.update(newOffer);
 
 		tradesList.add(0, flippingItem);
 	}
@@ -415,7 +415,7 @@ public class FlippingPlugin extends Plugin
 	private void updateFlippingItem(FlippingItem flippingItem, OfferInfo newOffer)
 	{
 		flippingItem.updateMargin(newOffer);
-		flippingItem.updateHistory(newOffer);
+		flippingItem.update(newOffer);
 
 		//When you have finished margin checking an item (when both the buy and sell prices have been updated) and the auto
 		//freeze config option has been selected, freeze the item's margin.
@@ -596,25 +596,25 @@ public class FlippingPlugin extends Plugin
 				if (offerText.equals("Buy offer"))
 				{
 					//No recorded data; hide the widget
-					if (selectedItem == null || selectedItem.getLatestBuyPrice() == 0)
+					if (selectedItem == null || selectedItem.getMarginCheckBuyPrice() == 0)
 					{
 						flippingWidget.showWidget("reset", 0);
 					}
 					else
 					{
-						flippingWidget.showWidget("setBuyPrice", selectedItem.getLatestBuyPrice());
+						flippingWidget.showWidget("setBuyPrice", selectedItem.getMarginCheckBuyPrice());
 					}
 				}
 				else if (offerText.equals("Sell offer"))
 				{
 					//No recorded data; hide the widget
-					if (selectedItem == null || selectedItem.getLatestSellPrice() == 0)
+					if (selectedItem == null || selectedItem.getMarginCheckSellPrice() == 0)
 					{
 						flippingWidget.showWidget("reset", 0);
 					}
 					else
 					{
-						flippingWidget.showWidget("setSellPrice", selectedItem.getLatestSellPrice());
+						flippingWidget.showWidget("setSellPrice", selectedItem.getMarginCheckSellPrice());
 					}
 				}
 			}

--- a/src/main/java/com/flippingutilities/HistoryManager.java
+++ b/src/main/java/com/flippingutilities/HistoryManager.java
@@ -47,7 +47,8 @@ public class HistoryManager
 	/**
 	 * This method takes in every new offer that comes and updates the standardized offer list along with
 	 * other properties related to the history of an item such as how many items were bought since the last
-	 * ge limit refresh and how when the ge limit will reset again.
+	 * ge limit refresh and how when the ge limit will reset again. The standardized offer list is used to
+	 * calculate profit for the item.
 	 *
 	 * @param newOffer the OfferInfo object created from the {@link GrandExchangeOfferChanged} event that
 	 *                 onGrandExchangeOfferChanged (in FlippingPlugin) receives

--- a/src/main/java/com/flippingutilities/ui/flipping/FlippingItemPanel.java
+++ b/src/main/java/com/flippingutilities/ui/flipping/FlippingItemPanel.java
@@ -119,8 +119,8 @@ public class FlippingItemPanel extends JPanel
 	FlippingItemPanel(final FlippingPlugin plugin, final ItemManager itemManager, final FlippingItem flippingItem)
 	{
 		this.flippingItem = flippingItem;
-		this.buyPrice = this.flippingItem.getLatestBuyPrice();
-		this.sellPrice = this.flippingItem.getLatestSellPrice();
+		this.buyPrice = this.flippingItem.getMarginCheckBuyPrice();
+		this.sellPrice = this.flippingItem.getMarginCheckSellPrice();
 		this.plugin = plugin;
 
 		final int itemID = flippingItem.getItemId();
@@ -324,8 +324,8 @@ public class FlippingItemPanel extends JPanel
 	public void buildPanelValues()
 	{
 		//Update latest price
-		this.buyPrice = flippingItem.getLatestBuyPrice();
-		this.sellPrice = flippingItem.getLatestSellPrice();
+		this.buyPrice = flippingItem.getMarginCheckBuyPrice();
+		this.sellPrice = flippingItem.getMarginCheckSellPrice();
 
 		int roiGradientMax = plugin.getConfig().roiGradientMax();
 
@@ -422,8 +422,8 @@ public class FlippingItemPanel extends JPanel
 	public void updatePriceOutdatedDisplay()
 	{
 		//Update time of latest price update.
-		Instant latestBuyTime = flippingItem.getLatestBuyTime();
-		Instant latestSellTime = flippingItem.getLatestSellTime();
+		Instant latestBuyTime = flippingItem.getMarginCheckBuyTime();
+		Instant latestSellTime = flippingItem.getMarginCheckSellTime();
 
 		//Update price texts with the string formatter
 		final String latestBuyString = formatPriceTimeText(latestBuyTime) + " old";


### PR DESCRIPTION
### Changes:

**in Flipping item**:
1. renamed latestBuyPrice to marginCheckBuyPrice, renamed latestSellPrice to marginCheckSellPrice, renamed latestSellTime to marginCheckSellTime, renamed latestBuyTime to marginCheckBuyTime. I am open to renaming these as I think they could still be named better. The reason I renamed them was because I wanted to differentiate the prices/times of the margin check and a non margin check offer.

2. added two variables, latestSellTime and latestBuyTime. (changed the existing variables that were previous named this in point 1.)

3. added a new method called ```updateLatestBuySellTimes(OfferInfo newOffer)```

4. added a new method called ```update(OfferInfo newOffer)``` in FlippingItem which just calls updateHistory and updateLatestBuySellTimes. This method is invoked every time we get a new offer as both the history of an item and the latest buy or sell times always change in response to a new offer event.

**FlippingPlugin**:
1. Since I renamed some stuff in FlippingItem I just needed to change the calls to them in FlippingPLugin

**HistoryManager**:
1. small comment change clarifying what "history" is used for

**FlippingItemPanel**:
1. Since I renamed some stuff in FlippingItem I just needed to change the calls to them in FlippingItemPanel.

