### PR TITLE
added automatic margin updating

### DIFF
--- a/src/main/java/com/flippingutilities/FlippingConfig.java
+++ b/src/main/java/com/flippingutilities/FlippingConfig.java
@@ -96,15 +96,4 @@ public interface FlippingConfig extends Config
 		return false;
 	}
 
-	@ConfigItem(
-			keyName = "autoFreezeMargin",
-			name = "Automatically freeze the margin of new items.",
-
-			description = "Ensures that every item that gets added has its margin frozen to prevent its "
-					+ "margin from being updated by subsequent buys/sells of one."
-	)
-	default boolean autoFreezeMargin()
-	{
-		return false;
-	}
 }

--- a/src/main/java/com/flippingutilities/FlippingItem.java
+++ b/src/main/java/com/flippingutilities/FlippingItem.java
@@ -29,7 +29,6 @@ package com.flippingutilities;
 import com.flippingutilities.ui.flipping.FlippingItemPanel;
 import java.time.Instant;
 import lombok.Getter;
-import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.events.GrandExchangeOfferChanged;
 
@@ -73,16 +72,6 @@ public class FlippingItem
 	@Getter
 	private Instant latestSellTime;
 
-	@Getter
-	@Setter
-	private boolean isFrozen = false;
-
-	@Getter
-	private boolean sellPriceNeedsUpdate = true;
-
-	@Getter
-	private boolean buyPriceNeedsUpdate = true;
-
 	private HistoryManager history = new HistoryManager();
 
 
@@ -101,7 +90,8 @@ public class FlippingItem
 	 *
 	 * @param newOffer new offer just received
 	 */
-	public void update(OfferInfo newOffer) {
+	public void update(OfferInfo newOffer)
+	{
 		updateHistory(newOffer);
 		updateLatestBuySellTimes(newOffer);
 	}
@@ -148,20 +138,18 @@ public class FlippingItem
 		int tradePrice = newOffer.getPrice();
 		Instant tradeTime = newOffer.getTime();
 
-		if (!(isFrozen))
+
+		if (tradeBuyState)
 		{
-			if (tradeBuyState)
-			{
-				marginCheckSellPrice = tradePrice;
-				marginCheckSellTime = tradeTime;
-				sellPriceNeedsUpdate = false;
-			}
-			else
-			{
-				marginCheckBuyPrice = tradePrice;
-				marginCheckBuyTime = tradeTime;
-				buyPriceNeedsUpdate = false;
-			}
+			marginCheckSellPrice = tradePrice;
+			marginCheckSellTime = tradeTime;
+
+		}
+		else
+		{
+			marginCheckBuyPrice = tradePrice;
+			marginCheckBuyTime = tradeTime;
+
 		}
 	}
 
@@ -193,33 +181,6 @@ public class FlippingItem
 	public void validateGeProperties()
 	{
 		history.validateGeProperties();
-	}
-
-
-	/**
-	 * This Method is responsible for freezing an item's margin. When an item is to be frozen, buyPriceNeedsUpdate and
-	 * sellPriceNeeds update are set to true, and isFrozen is set to false. isFrozen is set to false so that
-	 * updateMargin will update the margins and so that the components that rely on a FlippingItem can easily
-	 * see that it is frozen. BuyPriceNeedsUpdate and sellPriceNeedsUpdate are set to true, so that in
-	 * {@link FlippingPlugin#updateFlippingItem(FlippingItem, OfferInfo)} when an item is being updated, the margin
-	 * is only frozen again if BOTH the sell price and buy price are updated.
-	 *
-	 * @param freeze whether the item should have it's margin frozen or not
-	 */
-	public void freezeMargin(boolean freeze)
-	{
-		if (freeze)
-		{
-			isFrozen = true;
-			buyPriceNeedsUpdate = false;
-			sellPriceNeedsUpdate = false;
-		}
-		else
-		{
-			isFrozen = false;
-			buyPriceNeedsUpdate = true;
-			sellPriceNeedsUpdate = true;
-		}
 	}
 
 }

--- a/src/main/java/com/flippingutilities/FlippingPlugin.java
+++ b/src/main/java/com/flippingutilities/FlippingPlugin.java
@@ -133,7 +133,7 @@ public class FlippingPlugin extends Plugin
 
 
 	//will store the last seen events for each GE slot and so that we can screen out duplicate/bad events
-	private Map<Integer, GrandExchangeOffer> lastOffers = new HashMap<>();
+	private Map<Integer, OfferInfo> lastOffers = new HashMap<>();
 
 	@Override
 	protected void startUp()
@@ -256,12 +256,15 @@ public class FlippingPlugin extends Plugin
 	@Subscribe
 	public void onGrandExchangeOfferChanged(GrandExchangeOfferChanged newOfferEvent)
 	{
-		if (isBadEvent(newOfferEvent))
+		OfferInfo newOffer = extractRelevantInfo(newOfferEvent);
+
+		if (isBadOffer(newOffer))
 		{
 			return;
 		}
 
-		final OfferInfo newOffer = tradeConstructor(newOfferEvent);
+		System.out.println(newOffer);
+
 		Optional<FlippingItem> flippingItem = findItemInTradesList(newOffer.getItemId());
 
 		if (newOffer.isMarginCheck())
@@ -291,62 +294,57 @@ public class FlippingPlugin extends Plugin
 		flippingPanel.updateActivePanelsGePropertiesDisplay();
 	}
 
+
 	/**
-	 * Runelite has some wonky events at times. For example, every buy/sell/cancelled buy/cancelled sell
+	 * Runelite has some wonky events at times. For example, every empty/buy/sell/cancelled buy/cancelled sell
 	 * spawns two identical events. And when you fully buy/sell item, it also spawns two events (a
-	 * buying/selling event and a bought/sold event). This screens out the unwanted events/duplicate
-	 * events
+	 * buying/selling event and a bought/sold event). This method screens out the unwanted events/duplicate
+	 * events and also sets the ticks since the first offer in that slot to help with figuring out whether
+	 * an offer is a margin check.
 	 *
-	 * @param newOfferEvent
+	 * @param newOffer
 	 * @return a boolean representing whether the offer should be passed on or discarded
 	 */
-	private boolean isBadEvent(GrandExchangeOfferChanged newOfferEvent)
+	private boolean isBadOffer(OfferInfo newOffer)
 	{
-		GrandExchangeOffer newOffer = newOfferEvent.getOffer();
-		int newOfferSlot = newOfferEvent.getSlot();
+		//i am mutating offers and they are being passed around, so i'm cloning to avoid passing the same reference around.
+		OfferInfo clonedNewOffer = newOffer.clone();
 
-		//Check for login screen and empty offers.
-		if (newOffer.getQuantitySold() == 0 || newOfferEvent.getOffer().getItemId() == 0)
+		//Check empty offers.
+		if (clonedNewOffer.getItemId() == 0 || clonedNewOffer.getState() == GrandExchangeOfferState.EMPTY)
 		{
 			return true;
 		}
 
-		//if its the last selling/buying event, as evidenced by the quantity sold/bought being
-		//equal to the total quantity of the offer, record it but return true so it doesn't go through
-		//as the next event will be a BOUGHT/SOLD event, and only that should go through.
-		if ((newOffer.getState() == GrandExchangeOfferState.BUYING || newOffer.getState() == GrandExchangeOfferState.SELLING) && newOffer.getQuantitySold() == newOffer.getTotalQuantity())
+		//this is always the start of any offer (when you first put in an offer)
+		if (clonedNewOffer.getQuantity() == 0)
 		{
-			lastOffers.put(newOfferSlot, newOffer);
+			lastOffers.put(clonedNewOffer.getSlot(), clonedNewOffer);//tickSinceFirstOffer is 0 here
 			return true;
 		}
 
-
-		//if there is a last seen offer for that slot
-		if (lastOffers.containsKey(newOfferSlot))
+		//when an offer is complete, two events are generated: a buying/selling event and a bought/sold event.
+		//this clause ignores the buying/selling event as it conveys the same info. We can tell its the buying/selling
+		//event right before a bought/sold event due to the quantity of the offer being == to the total quantity of the offer.
+		if ((clonedNewOffer.getState() == GrandExchangeOfferState.BUYING || clonedNewOffer.getState() == GrandExchangeOfferState.SELLING) && clonedNewOffer.getQuantity() == newOffer.getTotalQuantity())
 		{
-
-			GrandExchangeOffer lastOfferForSlot = lastOffers.get(newOfferSlot);
-
-			//if its a duplicate as the last seen event
-			if (lastOfferForSlot.getState().equals(newOffer.getState()) && lastOfferForSlot.getQuantitySold() == newOffer.getQuantitySold())
-			{
-				return true; //its a bad event!
-			}
-
-			else
-			{
-				//update hashmap to include latest offer
-				lastOffers.put(newOfferSlot, newOffer);
-				return false; //not a bad event
-			}
+			return true;
 		}
-		//if there isn't a last seen offer for that slot
-		else
+
+		OfferInfo lastOfferForSlot = lastOffers.get(clonedNewOffer.getSlot());
+
+		//if its a duplicate as the last seen event
+		if (lastOfferForSlot.equals(clonedNewOffer))
 		{
-			//put the offer in the hashmap with the corresponding slot
-			lastOffers.put(newOfferSlot, newOffer);
-			return false;
+			return true;
 		}
+
+		int tickDiffFromLastOffer = clonedNewOffer.getTickArrivedAt() - lastOfferForSlot.getTickArrivedAt();
+		clonedNewOffer.setTicksSinceFirstOffer(tickDiffFromLastOffer + lastOfferForSlot.getTicksSinceFirstOffer());
+		lastOffers.put(clonedNewOffer.getSlot(), clonedNewOffer);
+		newOffer.setTicksSinceFirstOffer(tickDiffFromLastOffer + lastOfferForSlot.getTicksSinceFirstOffer());
+		return false; //not a bad event
+
 	}
 
 	/**
@@ -356,8 +354,9 @@ public class FlippingPlugin extends Plugin
 	 * @param newOfferEvent new offer event just received
 	 * @return an OfferInfo with the relevant information.
 	 */
-	private OfferInfo tradeConstructor(GrandExchangeOfferChanged newOfferEvent)
+	private OfferInfo extractRelevantInfo(GrandExchangeOfferChanged newOfferEvent)
 	{
+
 		GrandExchangeOffer offer = newOfferEvent.getOffer();
 
 		boolean isBuy = offer.getState() == GrandExchangeOfferState.BOUGHT || offer.getState() == GrandExchangeOfferState.CANCELLED_BUY || offer.getState() == GrandExchangeOfferState.BUYING;
@@ -366,10 +365,13 @@ public class FlippingPlugin extends Plugin
 			isBuy,
 			offer.getItemId(),
 			offer.getQuantitySold(),
-			offer.getSpent() / offer.getQuantitySold(),
+			offer.getQuantitySold() == 0 ? 0 : offer.getSpent() / offer.getQuantitySold(),
 			Instant.now(),
 			newOfferEvent.getSlot(),
-			offer.getState());
+			offer.getState(),
+			client.getTickCount(),
+			0,
+			offer.getTotalQuantity());
 
 		return offerInfo;
 

--- a/src/main/java/com/flippingutilities/FlippingPlugin.java
+++ b/src/main/java/com/flippingutilities/FlippingPlugin.java
@@ -271,7 +271,8 @@ public class FlippingPlugin extends Plugin
 		{
 			if (flippingItem.isPresent())
 			{
-				updateFlippingItem(flippingItem.get(), newOffer);
+				flippingItem.get().update(newOffer);
+				flippingItem.get().updateMargin(newOffer);
 				tradesList.remove(flippingItem.get());
 				tradesList.add(0, flippingItem.get());
 			}
@@ -404,28 +405,6 @@ public class FlippingPlugin extends Plugin
 		flippingItem.update(newOffer);
 
 		tradesList.add(0, flippingItem);
-	}
-
-	/**
-	 * This method updates a flipping item by adding to its history and updating its margins. Since it updates
-	 * the margins of an item, it is only envoked when the offer is a margin check. This method is called in
-	 * {@link FlippingPlugin#onGrandExchangeOfferChanged}
-	 *
-	 * @param flippingItem flippingItem that is being updated.
-	 * @param newOffer     the offer that just came in.
-	 */
-	private void updateFlippingItem(FlippingItem flippingItem, OfferInfo newOffer)
-	{
-		flippingItem.updateMargin(newOffer);
-		flippingItem.update(newOffer);
-
-		//When you have finished margin checking an item (when both the buy and sell prices have been updated) and the auto
-		//freeze config option has been selected, freeze the item's margin.
-		if (!(flippingItem.isSellPriceNeedsUpdate()) && !(flippingItem.isBuyPriceNeedsUpdate()) && config.autoFreezeMargin())
-		{
-			flippingItem.setFrozen(true);
-		}
-
 	}
 
 	@Provides

--- a/src/main/java/com/flippingutilities/OfferInfo.java
+++ b/src/main/java/com/flippingutilities/OfferInfo.java
@@ -27,6 +27,9 @@ public class OfferInfo
 	private Instant time;
 	private int slot;
 	private GrandExchangeOfferState state;
+	private int tickArrivedAt;
+	private int ticksSinceFirstOffer;
+	private int totalQuantity;
 
 	/**
 	 * Returns a boolean representing that the offer is a complete offer. A complete offer signifies
@@ -53,7 +56,8 @@ public class OfferInfo
 	 */
 	public boolean isMarginCheck()
 	{
-		return (state == GrandExchangeOfferState.BOUGHT || state == GrandExchangeOfferState.SOLD) && quantity == 1;
+		return (state == GrandExchangeOfferState.BOUGHT || state == GrandExchangeOfferState.SOLD) && quantity == 1
+			&& ticksSinceFirstOffer <= 2;
 	}
 
 	/**
@@ -77,8 +81,22 @@ public class OfferInfo
 	//TODO actually clone the Instant object, as we are currently just passing that as the same reference.
 	public OfferInfo clone()
 	{
-		OfferInfo clonedOffer = new OfferInfo(buy, itemId, quantity, price, time, slot, state);
+		OfferInfo clonedOffer = new OfferInfo(buy, itemId, quantity, price, time, slot, state, tickArrivedAt, ticksSinceFirstOffer, totalQuantity);
 		return clonedOffer;
+	}
+
+	public boolean equals(Object other) {
+		if (other == this) {
+			return true;
+		}
+
+		if (!(other instanceof OfferInfo)) {
+			return false;
+		}
+
+		OfferInfo otherOffer = (OfferInfo) other;
+
+		return getState()==otherOffer.getState() && getQuantity() == otherOffer.getQuantity();
 	}
 }
 

--- a/src/main/java/com/flippingutilities/ui/flipping/FlippingItemPanel.java
+++ b/src/main/java/com/flippingutilities/ui/flipping/FlippingItemPanel.java
@@ -164,32 +164,9 @@ public class FlippingItemPanel extends JPanel
 		/* Item name panel */
 		itemName = new JLabel(flippingItem.getItemName(), SwingConstants.CENTER);
 
-		itemName.setForeground(flippingItem.isFrozen() ? FROZEN_COLOR : Color.WHITE);
+		itemName.setForeground(Color.WHITE);
 		itemName.setFont(FontManager.getRunescapeBoldFont());
 		itemName.setPreferredSize(new Dimension(0, 0)); //Make sure the item name fits
-
-		//Margin freezing controller
-		itemName.setToolTipText("Right-click to freeze item's margin");
-		itemName.addMouseListener(new MouseAdapter()
-		{
-			@Override
-			public void mousePressed(MouseEvent e)
-			{
-				if (SwingUtilities.isRightMouseButton(e))
-				{
-					if (flippingItem.isFrozen())
-					{
-						flippingItem.freezeMargin(false);
-						itemName.setForeground(Color.WHITE);
-					}
-					else
-					{
-						flippingItem.freezeMargin(true);
-						itemName.setForeground(FROZEN_COLOR);
-					}
-				}
-			}
-		});
 
 		topPanel.setBackground(background.darker());
 		topPanel.add(itemClearPanel, BorderLayout.WEST);
@@ -568,18 +545,5 @@ public class FlippingItemPanel extends JPanel
 					+ ".<html>");
 			}
 		});
-	}
-
-	/**
-	 * Freezes or unfreezes the margin display along with the margin of the underlying FlippingItem
-	 *
-	 * @param freeze whether the margin display and underlyingFlippingItem should be frozen
-	 *               or not.
-	 */
-	public void freezeMargin(boolean freeze)
-	{
-		flippingItem.freezeMargin(freeze);
-		itemName.setForeground(flippingItem.isFrozen() ? FROZEN_COLOR : Color.WHITE);
-
 	}
 }

--- a/src/main/java/com/flippingutilities/ui/flipping/FlippingPanel.java
+++ b/src/main/java/com/flippingutilities/ui/flipping/FlippingPanel.java
@@ -416,16 +416,4 @@ public class FlippingPanel extends JPanel
 		rebuildFlippingPanel(result);
 	}
 
-	/**
-	 * Freezes or unfreezes all the activePanel's margin displays along with the underlying FlippingItem's margin
-	 *
-	 * @param freeze whether the panel/item should be frozen or not.
-	 */
-	private void freezeActivePanels(boolean freeze)
-	{
-		for (FlippingItemPanel panel : activePanels)
-		{
-			panel.freezeMargin(freeze);
-		}
-	}
 }

--- a/src/test/java/com/flippingutilities/HistoryManagerTest.java
+++ b/src/test/java/com/flippingutilities/HistoryManagerTest.java
@@ -23,22 +23,22 @@ public class HistoryManagerTest
 		//overall bought 24+3+20=47
 		//overall sold 7 + 3 + 30 = 40
 		//5gp profit each
-		offers.add(new OfferInfo(true, 0, 7, 100, baseTime.minus(40, ChronoUnit.MINUTES), 1, GrandExchangeOfferState.BUYING));
-		offers.add(new OfferInfo(true, 0, 13, 100, baseTime.minus(30, ChronoUnit.MINUTES), 1, GrandExchangeOfferState.BUYING));
-		offers.add(new OfferInfo(true, 0, 24, 100, baseTime.minus(20, ChronoUnit.MINUTES), 1, GrandExchangeOfferState.BOUGHT));
+		offers.add(new OfferInfo(true, 0, 7, 100, baseTime.minus(40, ChronoUnit.MINUTES), 1, GrandExchangeOfferState.BUYING,0,0,0));
+		offers.add(new OfferInfo(true, 0, 13, 100, baseTime.minus(30, ChronoUnit.MINUTES), 1, GrandExchangeOfferState.BUYING,0,0,0));
+		offers.add(new OfferInfo(true, 0, 24, 100, baseTime.minus(20, ChronoUnit.MINUTES), 1, GrandExchangeOfferState.BOUGHT,0,0,0));
 
-		offers.add(new OfferInfo(false, 0, 7, 105, baseTime.minus(15, ChronoUnit.MINUTES), 3, GrandExchangeOfferState.SOLD));
-		offers.add(new OfferInfo(false, 0, 3, 105, baseTime.minus(12, ChronoUnit.MINUTES), 4, GrandExchangeOfferState.SELLING));
-		offers.add(new OfferInfo(false, 0, 3, 105, baseTime.minus(12, ChronoUnit.MINUTES), 4, GrandExchangeOfferState.CANCELLED_SELL));
+		offers.add(new OfferInfo(false, 0, 7, 105, baseTime.minus(15, ChronoUnit.MINUTES), 3, GrandExchangeOfferState.SOLD,0,0,0));
+		offers.add(new OfferInfo(false, 0, 3, 105, baseTime.minus(12, ChronoUnit.MINUTES), 4, GrandExchangeOfferState.SELLING,0,0,0));
+		offers.add(new OfferInfo(false, 0, 3, 105, baseTime.minus(12, ChronoUnit.MINUTES), 4, GrandExchangeOfferState.CANCELLED_SELL,0,0,0));
 
-		offers.add(new OfferInfo(true, 0, 3, 100, baseTime.minus(10, ChronoUnit.MINUTES), 2, GrandExchangeOfferState.BOUGHT));
-		offers.add(new OfferInfo(true, 0, 10, 100, baseTime.minus(9, ChronoUnit.MINUTES), 2, GrandExchangeOfferState.BUYING));
-		offers.add(new OfferInfo(true, 0, 20, 100, baseTime.minus(7, ChronoUnit.MINUTES), 2, GrandExchangeOfferState.BOUGHT));
+		offers.add(new OfferInfo(true, 0, 3, 100, baseTime.minus(10, ChronoUnit.MINUTES), 2, GrandExchangeOfferState.BOUGHT,0,0,0));
+		offers.add(new OfferInfo(true, 0, 10, 100, baseTime.minus(9, ChronoUnit.MINUTES), 2, GrandExchangeOfferState.BUYING,0,0,0));
+		offers.add(new OfferInfo(true, 0, 20, 100, baseTime.minus(7, ChronoUnit.MINUTES), 2, GrandExchangeOfferState.BOUGHT,0,0,0));
 
 
-		offers.add(new OfferInfo(false, 0, 10, 105, baseTime.minus(6, ChronoUnit.MINUTES), 1, GrandExchangeOfferState.SELLING));
-		offers.add(new OfferInfo(false, 0, 20, 105, baseTime.minus(5, ChronoUnit.MINUTES), 1, GrandExchangeOfferState.SELLING));
-		offers.add(new OfferInfo(false, 0, 30, 105, baseTime.minus(4, ChronoUnit.MINUTES), 1, GrandExchangeOfferState.SOLD));
+		offers.add(new OfferInfo(false, 0, 10, 105, baseTime.minus(6, ChronoUnit.MINUTES), 1, GrandExchangeOfferState.SELLING,0,0,0));
+		offers.add(new OfferInfo(false, 0, 20, 105, baseTime.minus(5, ChronoUnit.MINUTES), 1, GrandExchangeOfferState.SELLING,0,0,0));
+		offers.add(new OfferInfo(false, 0, 30, 105, baseTime.minus(4, ChronoUnit.MINUTES), 1, GrandExchangeOfferState.SOLD,0,0,0));
 
 		historyManager = new HistoryManager();
 		for (OfferInfo offer : offers)
@@ -51,22 +51,22 @@ public class HistoryManagerTest
 	public void offersAreCorrectlyStandardizedTest()
 	{
 		List<OfferInfo> standardizedOffers = new ArrayList<>();
-		standardizedOffers.add(new OfferInfo(true, 0, 7, 100, baseTime.minus(40, ChronoUnit.MINUTES), 1, GrandExchangeOfferState.BUYING));
-		standardizedOffers.add(new OfferInfo(true, 0, 6, 100, baseTime.minus(30, ChronoUnit.MINUTES), 1, GrandExchangeOfferState.BUYING));
-		standardizedOffers.add(new OfferInfo(true, 0, 11, 100, baseTime.minus(20, ChronoUnit.MINUTES), 1, GrandExchangeOfferState.BOUGHT));
+		standardizedOffers.add(new OfferInfo(true, 0, 7, 100, baseTime.minus(40, ChronoUnit.MINUTES), 1, GrandExchangeOfferState.BUYING,0,0,0));
+		standardizedOffers.add(new OfferInfo(true, 0, 6, 100, baseTime.minus(30, ChronoUnit.MINUTES), 1, GrandExchangeOfferState.BUYING,0,0,0));
+		standardizedOffers.add(new OfferInfo(true, 0, 11, 100, baseTime.minus(20, ChronoUnit.MINUTES), 1, GrandExchangeOfferState.BOUGHT,0,0,0));
 
-		standardizedOffers.add(new OfferInfo(false, 0, 7, 105, baseTime.minus(15, ChronoUnit.MINUTES), 3, GrandExchangeOfferState.SOLD));
-		standardizedOffers.add(new OfferInfo(false, 0, 3, 105, baseTime.minus(12, ChronoUnit.MINUTES), 4, GrandExchangeOfferState.SELLING));
-		standardizedOffers.add(new OfferInfo(false, 0, 0, 105, baseTime.minus(12, ChronoUnit.MINUTES), 4, GrandExchangeOfferState.CANCELLED_SELL));
+		standardizedOffers.add(new OfferInfo(false, 0, 7, 105, baseTime.minus(15, ChronoUnit.MINUTES), 3, GrandExchangeOfferState.SOLD,0,0,0));
+		standardizedOffers.add(new OfferInfo(false, 0, 3, 105, baseTime.minus(12, ChronoUnit.MINUTES), 4, GrandExchangeOfferState.SELLING,0,0,0));
+		standardizedOffers.add(new OfferInfo(false, 0, 0, 105, baseTime.minus(12, ChronoUnit.MINUTES), 4, GrandExchangeOfferState.CANCELLED_SELL,0,0,0));
 
-		standardizedOffers.add(new OfferInfo(true, 0, 3, 100, baseTime.minus(10, ChronoUnit.MINUTES), 2, GrandExchangeOfferState.BOUGHT));
-		standardizedOffers.add(new OfferInfo(true, 0, 10, 100, baseTime.minus(9, ChronoUnit.MINUTES), 2, GrandExchangeOfferState.BUYING));
-		standardizedOffers.add(new OfferInfo(true, 0, 10, 100, baseTime.minus(7, ChronoUnit.MINUTES), 2, GrandExchangeOfferState.BOUGHT));
+		standardizedOffers.add(new OfferInfo(true, 0, 3, 100, baseTime.minus(10, ChronoUnit.MINUTES), 2, GrandExchangeOfferState.BOUGHT,0,0,0));
+		standardizedOffers.add(new OfferInfo(true, 0, 10, 100, baseTime.minus(9, ChronoUnit.MINUTES), 2, GrandExchangeOfferState.BUYING,0,0,0));
+		standardizedOffers.add(new OfferInfo(true, 0, 10, 100, baseTime.minus(7, ChronoUnit.MINUTES), 2, GrandExchangeOfferState.BOUGHT,0,0,0));
 
 
-		standardizedOffers.add(new OfferInfo(false, 0, 10, 105, baseTime.minus(6, ChronoUnit.MINUTES), 1, GrandExchangeOfferState.SELLING));
-		standardizedOffers.add(new OfferInfo(false, 0, 10, 105, baseTime.minus(5, ChronoUnit.MINUTES), 1, GrandExchangeOfferState.SELLING));
-		standardizedOffers.add(new OfferInfo(false, 0, 10, 105, baseTime.minus(4, ChronoUnit.MINUTES), 1, GrandExchangeOfferState.SOLD));
+		standardizedOffers.add(new OfferInfo(false, 0, 10, 105, baseTime.minus(6, ChronoUnit.MINUTES), 1, GrandExchangeOfferState.SELLING,0,0,0));
+		standardizedOffers.add(new OfferInfo(false, 0, 10, 105, baseTime.minus(5, ChronoUnit.MINUTES), 1, GrandExchangeOfferState.SELLING,0,0,0));
+		standardizedOffers.add(new OfferInfo(false, 0, 10, 105, baseTime.minus(4, ChronoUnit.MINUTES), 1, GrandExchangeOfferState.SOLD,0,0,0));
 
 
 		assertEquals(standardizedOffers, historyManager.getStandardizedOffers());
@@ -76,7 +76,7 @@ public class HistoryManagerTest
 	public void getProfitCorrectnessTest()
 	{
 		assertEquals(200, historyManager.currentProfit(baseTime.minus(1, ChronoUnit.HOURS)));
-		historyManager.updateHistory(new OfferInfo(false, 0, 5, 105, baseTime.minus(4, ChronoUnit.MINUTES), 1, GrandExchangeOfferState.SOLD));
+		historyManager.updateHistory(new OfferInfo(false, 0, 5, 105, baseTime.minus(4, ChronoUnit.MINUTES), 1, GrandExchangeOfferState.SOLD,0,0,0));
 		assertEquals(34 * 5, historyManager.currentProfit(baseTime.minus(25, ChronoUnit.MINUTES))); //34 buys and 40 sells, so looks for 34 items and profit is 5 gp ea.
 		assertEquals(0, historyManager.currentProfit(baseTime));
 
@@ -87,7 +87,7 @@ public class HistoryManagerTest
 	{
 		HistoryManager historyManager = new HistoryManager();
 
-		OfferInfo offer1 = new OfferInfo(true, 0, 7, 100, baseTime.minus(4, ChronoUnit.HOURS), 1, GrandExchangeOfferState.BUYING);
+		OfferInfo offer1 = new OfferInfo(true, 0, 7, 100, baseTime.minus(4, ChronoUnit.HOURS), 1, GrandExchangeOfferState.BUYING,0,0,0);
 
 		//buy 7 of an item 4 hours ago
 		historyManager.updateHistory(offer1);
@@ -95,14 +95,14 @@ public class HistoryManagerTest
 		assertEquals(offer1.getTime().plus(4, ChronoUnit.HOURS), historyManager.getNextGeLimitRefresh());
 
 		//buy another 3 of that item 3 hours ago, so the amount you bought before the ge limit has refreshed is now 10
-		OfferInfo offer2 = new OfferInfo(true, 0, 10, 100, baseTime.minus(3, ChronoUnit.HOURS), 1, GrandExchangeOfferState.BOUGHT);
+		OfferInfo offer2 = new OfferInfo(true, 0, 10, 100, baseTime.minus(3, ChronoUnit.HOURS), 1, GrandExchangeOfferState.BOUGHT,0,0,0);
 		historyManager.updateHistory(offer2);
 		assertEquals(10, historyManager.getItemsBoughtThisLimitWindow());
 		assertEquals(offer1.getTime().plus(4, ChronoUnit.HOURS), historyManager.getNextGeLimitRefresh());
 
 		//buy another 1 of that item, but 1 minute in the future, so more than 4 hours from the first purchase of the item. By this time, the ge limit has reset
 		//so the amount you bought after the last ge refresh is 1.
-		OfferInfo offer3 = new OfferInfo(true, 0, 1, 100, baseTime.plus(1, ChronoUnit.MINUTES), 1, GrandExchangeOfferState.BUYING);
+		OfferInfo offer3 = new OfferInfo(true, 0, 1, 100, baseTime.plus(1, ChronoUnit.MINUTES), 1, GrandExchangeOfferState.BUYING,0,0,0);
 		historyManager.updateHistory(offer3);
 		assertEquals(1, historyManager.getItemsBoughtThisLimitWindow());
 		assertEquals(offer3.getTime().plus(4, ChronoUnit.HOURS), historyManager.getNextGeLimitRefresh());


### PR DESCRIPTION
**Huge thanks to @Belieal for thinking about using ticks to time the state change as a way to check whether an offer was a margin check or not.**

Previously any  bought/sold offer with a quantity of 1 would count as a margin check which lead to the user having to freeze the margin if they didn't want subsequent buy/sells of one to change the current margin display.

Now, we check whether an offer is a margin check by not only seeing if it was a quantity of 1, but also whether the state change from an empty offer (when you first place an offer) to a complete offer is "instant" (no greater than a 2 tick difference).

The reason it's a 2 tick difference is because each time a you place an offer in the GE, it generates a buying/selling event that is empty. Then, the next tick, IF the item was bought/sold, it generates a buying/selling event, which on the next tick, causes a bought/sold event. So the time difference between the last event and the first event in the fastest case, is 2. This is the fastest case because the item was bought/sold as soon as it could have after you placed the offer in (it can't happen in the same tick, so the next best is the tick after). 

If the difference is any greater than that, it wasn't an insta buy/sell (meaning you weren't the best offer on the market) and thus wasn't a margin check.


Changes:
1. changed OfferInfo as now it takes some additional pieces of info (tickSinceFirstOffer and tickArriveAt)

2. renamed isBadEvent to isBadOffer. As now it takes in an offer and looks at it compared to the previous offers in that slot. If it is an empty offer (these come on login), it throws it away. If it is an offer with a quantity of 0 but its state is buying or selling, it stores it as this is the event generated when you first place an offer in the GE (the empty buying/selling event) and is used to calculate how many ticks until the offer is completed. If it's a duplicate offer as compared to the last it throws it away. If it is the buying/selling event generated right before the bought/sold event, it throws it away. If it is none of the above, it stores it and sets its ticksSinceFirstOffer by looking at the difference between the tickArrivedAt of the current offer and the last offer and adding it to the ticksSinceFirstOffer.

Essentially, when we get an event, we create an OfferInfo out of it with some defaults and pass it to isBadOffer. IsBadOffer throws it away if its a EMPTY/duplicate offer. If it's not a bad offer, it stores it and sets its ticksSinceFirstOffer, so that it can compare the next offers it gets to this one and keep setting ticksSinceFirstOffer on the new ones appropriately.

The rest of the event pipeline is the exact same.




