### PR TITLE
Multi account functionality

### DIFF
--- a/src/main/java/com/flippingutilities/FlippingConfig.java
+++ b/src/main/java/com/flippingutilities/FlippingConfig.java
@@ -96,4 +96,17 @@ public interface FlippingConfig extends Config
 		return false;
 	}
 
+	@ConfigItem(
+		keyName = "multiAccTracking",
+		name = "multi account tracking",
+		description = "Enabling this feature gives you access to a dropdown which allows you to see each of your accounts" +
+			"flips and profits in isolation. This is very useful if you flip on multiple accounts."
+	)
+	default boolean multiAccTracking()
+	{
+		return false;
+	}
+
+
+
 }

--- a/src/main/java/com/flippingutilities/FlippingItem.java
+++ b/src/main/java/com/flippingutilities/FlippingItem.java
@@ -28,6 +28,8 @@ package com.flippingutilities;
 
 import com.flippingutilities.ui.flipping.FlippingItemPanel;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Optional;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -83,14 +85,18 @@ public class FlippingItem
 	@Getter
 	private boolean buyPriceNeedsUpdate = true;
 
+	@Getter
+	String flippedBy;
+
 	private HistoryManager history = new HistoryManager();
 
 
-	public FlippingItem(int itemId, String itemName, int totalGeLimit)
+	public FlippingItem(int itemId, String itemName, int totalGeLimit, String flippedBy)
 	{
 		this.itemId = itemId;
 		this.itemName = itemName;
 		this.totalGELimit = totalGeLimit;
+		this.flippedBy = flippedBy;
 	}
 
 	/**
@@ -101,7 +107,7 @@ public class FlippingItem
 	 *
 	 * @param newOffer new offer just received
 	 */
-	public void update(OfferInfo newOffer) {
+	public void updateHistoryAndTradedTime(OfferInfo newOffer) {
 		updateHistory(newOffer);
 		updateLatestBuySellTimes(newOffer);
 	}
@@ -137,8 +143,9 @@ public class FlippingItem
 
 	/**
 	 * This method is used to update the margin of an item. As such it is only invoked when an offer is a
-	 * margin check. It is invoked by {@link FlippingPlugin#updateFlippingItem} in the plugin class which itself is only
-	 * invoked when an offer is a margin check.
+	 * margin check. It is invoked by {@link FlippingPlugin#updateTradesList(ArrayList, Optional, OfferInfo)} when
+	 * an offer is figured out to be a margin.
+	 *
 	 *
 	 * @param newOffer the new offer just received.
 	 */
@@ -198,10 +205,10 @@ public class FlippingItem
 
 	/**
 	 * This Method is responsible for freezing an item's margin. When an item is to be frozen, buyPriceNeedsUpdate and
-	 * sellPriceNeeds update are set to true, and isFrozen is set to false. isFrozen is set to false so that
-	 * updateMargin will update the margins and so that the components that rely on a FlippingItem can easily
+	 * sellPriceNeeds updateHistoryAndTradedTime are set to true, and isFrozen is set to false. isFrozen is set to false so that
+	 * updateMargin will updateHistoryAndTradedTime the margins and so that the components that rely on a FlippingItem can easily
 	 * see that it is frozen. BuyPriceNeedsUpdate and sellPriceNeedsUpdate are set to true, so that in
-	 * {@link FlippingPlugin#updateFlippingItem(FlippingItem, OfferInfo)} when an item is being updated, the margin
+	 * {@link FlippingPlugin#shouldFreezeItem(FlippingItem)} when an item is being updated, the margin
 	 * is only frozen again if BOTH the sell price and buy price are updated.
 	 *
 	 * @param freeze whether the item should have it's margin frozen or not

--- a/src/main/java/com/flippingutilities/FlippingPlugin.java
+++ b/src/main/java/com/flippingutilities/FlippingPlugin.java
@@ -383,7 +383,7 @@ public class FlippingPlugin extends Plugin
 		//trades list won't be being updated.
 		if (newOffer.isMarginCheck() && (currentView.equals(loggedInUser) || currentView.equals(ACCOUNT_WIDE)))
 		{
-			flippingPanel.updateDisplays(getTradesForCurrentView());
+			flippingPanel.rebuildFlippingPanel(getTradesForCurrentView());
 		}
 
 		if (currentView.equals(loggedInUser) || currentView.equals(ACCOUNT_WIDE))
@@ -708,7 +708,7 @@ public class FlippingPlugin extends Plugin
 		executor.submit(() -> clientThread.invokeLater(() -> SwingUtilities.invokeLater(() ->
 		{
 			validateAllItems(trades);
-			flippingPanel.updateDisplays(trades);
+			flippingPanel.rebuildFlippingPanel(trades);
 			statPanel.updateDisplays(trades);
 		})));
 	}
@@ -787,7 +787,7 @@ public class FlippingPlugin extends Plugin
 				case ("roiGradientMax"):
 				case ("marginCheckLoss"):
 				case ("twelveHourFormat"):
-					flippingPanel.updateDisplays(getTradesForCurrentView());
+					flippingPanel.rebuildFlippingPanel(getTradesForCurrentView());
 					break;
 				default:
 					break;

--- a/src/main/java/com/flippingutilities/FlippingPlugin.java
+++ b/src/main/java/com/flippingutilities/FlippingPlugin.java
@@ -289,7 +289,6 @@ public class FlippingPlugin extends Plugin
 
 		if (selectedUsername.equals(ACCOUNT_WIDE))
 		{
-			log.info("selected view is account wide so showing account wide trades");
 			tradesListToDisplay = accountWideTrades;
 		}
 
@@ -298,12 +297,13 @@ public class FlippingPlugin extends Plugin
 			//look in cache, if its there just use it, otherwise set it from disk.
 			if (userTradelistCache.containsKey(selectedUsername))
 			{
-				log.info("history exists in cache");
+				log.info(String.format("history for %s exists in cache", selectedUsername));
 				tradesListToDisplay = userTradelistCache.get(selectedUsername);
 			}
 			else
 			{
-				log.info("history does not exist in cache, so its being loaded from disk");
+				log.info(String.format("history for %s does not exist in cache, so its being loaded from " +
+					"disk and the cache is being set", selectedUsername));
 				tradesListToDisplay = loadTradeHistory(KEY_PREFIX + selectedUsername);
 				userTradelistCache.put(selectedUsername, tradesListToDisplay);
 			}
@@ -658,7 +658,8 @@ public class FlippingPlugin extends Plugin
 				//account's tradeslist and thus loading it from disk into the cache that way.
 				if (!userTradelistCache.containsKey(loggedInUser))
 				{
-					log.info(String.format("loading trades for %s from disk", loggedInUser));
+					log.info(String.format("loading trades for %s from disk as they don't exist in the " +
+						"cache and setting the cache", loggedInUser));
 					ArrayList<FlippingItem> tradesFromDisk = loadTradeHistory(KEY_PREFIX + loggedInUser);
 					userTradelistCache.put(loggedInUser, tradesFromDisk);
 				}

--- a/src/main/java/com/flippingutilities/FlippingPlugin.java
+++ b/src/main/java/com/flippingutilities/FlippingPlugin.java
@@ -284,7 +284,7 @@ public class FlippingPlugin extends Plugin
 
 		Optional<FlippingItem> accountWideItem = findItemInTradesList(
 			accountWideTrades,
-			(item) -> item.getItemId() == newOffer.getItemId() && item.flippedBy == username);
+			(item) -> item.getItemId() == newOffer.getItemId() && item.flippedBy.equals(username));
 
 		updateTradesList(accountWideTrades, accountWideItem, newOffer);
 		updateTradesList(accountSpecificTrades, accountSpecificItem, newOffer);

--- a/src/main/java/com/flippingutilities/FlippingPlugin.java
+++ b/src/main/java/com/flippingutilities/FlippingPlugin.java
@@ -275,7 +275,7 @@ public class FlippingPlugin extends Plugin
 		{
 			return;
 		}
-		log.info("why is it getting through");
+
 		final OfferInfo newOffer = tradeConstructor(newOfferEvent);
 
 		Optional<FlippingItem> accountSpecificItem = findItemInTradesList(
@@ -568,6 +568,7 @@ public class FlippingPlugin extends Plugin
 			{
 				accountSpecificTrades = loadTradeHistory(username);
 				updateDisplays(accountSpecificTrades);
+				tabManager.setWhichTradesListDisplay(username);
 			}
 		}
 	}

--- a/src/main/java/com/flippingutilities/FlippingPlugin.java
+++ b/src/main/java/com/flippingutilities/FlippingPlugin.java
@@ -851,6 +851,7 @@ public class FlippingPlugin extends Plugin
 					}
 					else
 					{
+						tabManager.getViewSelector().setSelectedItem(ACCOUNT_WIDE);
 						tabManager.getViewSelector().setVisible(false);
 					}
 

--- a/src/main/java/com/flippingutilities/FlippingPlugin.java
+++ b/src/main/java/com/flippingutilities/FlippingPlugin.java
@@ -190,6 +190,9 @@ public class FlippingPlugin extends Plugin
 			return true;
 		});
 
+		//sets the account selector dropdown to visible or not depending on whether the config option has been selected.
+		tabManager.getViewSelector().setVisible(config.multiAccTracking());
+
 		//Ensures the panel displays for the margin check being outdated and the next ge refresh
 		//are updated every second.
 		timeUpdateFuture = executor.scheduleAtFixedRate(() ->
@@ -721,11 +724,12 @@ public class FlippingPlugin extends Plugin
 
 			//by setting a selected item, it runs changeView and thus updates the display. However, we only want to
 			//update the display if they the user has multiAcc tracking on.
-			if (config.multiAccTracking()) {
+			if (config.multiAccTracking())
+			{
+				currentView = loggedInUser;
 				tabManager.getViewSelector().setSelectedItem(loggedInUser);
 			}
 
-			currentView = loggedInUser;
 
 		}
 
@@ -841,10 +845,12 @@ public class FlippingPlugin extends Plugin
 					flippingPanel.rebuildFlippingPanel(getTradesForCurrentView());
 					break;
 				case ("multiAccTracking"):
-					if (config.multiAccTracking()) {
+					if (config.multiAccTracking())
+					{
 						tabManager.getViewSelector().setVisible(true);
 					}
-					else {
+					else
+					{
 						tabManager.getViewSelector().setVisible(false);
 					}
 

--- a/src/main/java/com/flippingutilities/FlippingPlugin.java
+++ b/src/main/java/com/flippingutilities/FlippingPlugin.java
@@ -290,7 +290,13 @@ public class FlippingPlugin extends Plugin
 		updateTradesList(accountSpecificTrades, accountSpecificItem, newOffer);
 
 		storeTradeHistory();
-		flippingPanel.rebuildFlippingPanel(accountSpecificTrades);
+
+		//only way items can float to the top of the list (hence requiring a rebuild) is when
+		//the offer is a margin check.
+		if (newOffer.isMarginCheck()) {
+			flippingPanel.rebuildFlippingPanel(accountSpecificTrades);
+		}
+
 		statPanel.updateDisplays();
 
 	}

--- a/src/main/java/com/flippingutilities/ui/TabManager.java
+++ b/src/main/java/com/flippingutilities/ui/TabManager.java
@@ -29,9 +29,13 @@ package com.flippingutilities.ui;
 import com.flippingutilities.ui.flipping.FlippingPanel;
 import com.flippingutilities.ui.statistics.StatisticsPanel;
 import java.awt.BorderLayout;
+import java.awt.Component;
 import javax.inject.Inject;
+import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.SwingConstants;
 import javax.swing.border.EmptyBorder;
+import lombok.Getter;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.PluginPanel;
 import net.runelite.client.ui.components.materialtabs.MaterialTab;
@@ -39,6 +43,9 @@ import net.runelite.client.ui.components.materialtabs.MaterialTabGroup;
 
 public class TabManager extends PluginPanel
 {
+
+
+	private JLabel whichTradesListLabel = new JLabel("Account wide list");
 
 	/**
 	 * This manages the tab navigation bar at the top of the panel.
@@ -56,7 +63,16 @@ public class TabManager extends PluginPanel
 		setLayout(new BorderLayout());
 		setBackground(ColorScheme.DARKER_GRAY_COLOR.darker());
 
+		whichTradesListLabel.setForeground(ColorScheme.GRAND_EXCHANGE_PRICE);
+		whichTradesListLabel.setHorizontalAlignment(SwingConstants.CENTER);
+
 		JPanel display = new JPanel();
+		JPanel top = new JPanel(new BorderLayout());
+
+		top.setBackground(ColorScheme.DARKER_GRAY_COLOR.darker());
+		top.setBorder(new EmptyBorder(5,0,0,0));
+		top.add(whichTradesListLabel, BorderLayout.NORTH);
+
 		MaterialTabGroup tabGroup = new MaterialTabGroup(display);
 		MaterialTab flippingTab = new MaterialTab("Flipping", tabGroup, flippingPanel);
 		MaterialTab statTab = new MaterialTab("Statistics", tabGroup, statPanel);
@@ -67,8 +83,13 @@ public class TabManager extends PluginPanel
 
 		// Initialize with flipping tab open.
 		tabGroup.select(flippingTab);
+		top.add(tabGroup, BorderLayout.CENTER);
 
-		add(tabGroup, BorderLayout.NORTH);
+		add(top, BorderLayout.NORTH);
 		add(display, BorderLayout.CENTER);
+	}
+
+	public void setWhichTradesListDisplay(String username) {
+		whichTradesListLabel.setText(String.format("%s's list",username));
 	}
 }

--- a/src/main/java/com/flippingutilities/ui/TabManager.java
+++ b/src/main/java/com/flippingutilities/ui/TabManager.java
@@ -48,9 +48,7 @@ public class TabManager extends PluginPanel
 	@Getter
 	private JComboBox<String> viewSelector = new JComboBox();
 
-	private FlippingPlugin plugin;
-
-	private String prevSelectedUsername = "accountwide";
+	private String prevSelectedUsername;
 
 	/**
 	 * This manages the tab navigation bar at the top of the panel.
@@ -63,14 +61,10 @@ public class TabManager extends PluginPanel
 	public TabManager(FlippingPlugin plugin, FlippingPanel flippingPanel, StatisticsPanel statPanel)
 	{
 		super(false);
-		this.plugin = plugin;
-
 
 		setLayout(new BorderLayout());
 		setBackground(ColorScheme.DARKER_GRAY_COLOR.darker());
 
-		viewSelector.addItem("accountwide");
-		viewSelector.setSelectedItem("accountwide");
 		viewSelector.setBackground(ColorScheme.DARKER_GRAY_COLOR);
 		viewSelector.setFocusable(false);
 		viewSelector.setForeground(ColorScheme.GRAND_EXCHANGE_PRICE);
@@ -85,7 +79,7 @@ public class TabManager extends PluginPanel
 				return;
 			}
 
-			if (!prevSelectedUsername.equals(selectedUsername))
+			if (!selectedUsername.equals(prevSelectedUsername) || prevSelectedUsername == null)
 			{
 				prevSelectedUsername = selectedUsername;
 				plugin.changeView(selectedUsername);

--- a/src/main/java/com/flippingutilities/ui/TabManager.java
+++ b/src/main/java/com/flippingutilities/ui/TabManager.java
@@ -86,6 +86,8 @@ public class TabManager extends PluginPanel
 			}
 		});
 
+		viewSelector.setVisible(false);
+
 		JPanel display = new JPanel();
 		//contains the tab group and the view selector combo box.
 		JPanel header = new JPanel(new BorderLayout());

--- a/src/main/java/com/flippingutilities/ui/TabManager.java
+++ b/src/main/java/com/flippingutilities/ui/TabManager.java
@@ -86,8 +86,6 @@ public class TabManager extends PluginPanel
 			}
 		});
 
-		viewSelector.setVisible(false);
-
 		JPanel display = new JPanel();
 		//contains the tab group and the view selector combo box.
 		JPanel header = new JPanel(new BorderLayout());

--- a/src/main/java/com/flippingutilities/ui/flipping/FlippingItemPanel.java
+++ b/src/main/java/com/flippingutilities/ui/flipping/FlippingItemPanel.java
@@ -421,7 +421,7 @@ public class FlippingItemPanel extends JPanel
 	 */
 	public void updatePriceOutdatedDisplay()
 	{
-		//Update time of latest price update.
+		//Update time of latest price updateHistoryAndTradedTime.
 		Instant latestBuyTime = flippingItem.getMarginCheckBuyTime();
 		Instant latestSellTime = flippingItem.getMarginCheckSellTime();
 

--- a/src/main/java/com/flippingutilities/ui/flipping/FlippingItemPanel.java
+++ b/src/main/java/com/flippingutilities/ui/flipping/FlippingItemPanel.java
@@ -318,6 +318,7 @@ public class FlippingItemPanel extends JPanel
 
 		add(topPanel, BorderLayout.NORTH);
 		add(itemInfo, BorderLayout.CENTER);
+		setToolTipText(String.format("Flipped by %s",flippingItem.getFlippedBy()));
 	}
 
 	//Creates, updates and sets the strings for the values to the right.

--- a/src/main/java/com/flippingutilities/ui/flipping/FlippingPanel.java
+++ b/src/main/java/com/flippingutilities/ui/flipping/FlippingPanel.java
@@ -177,7 +177,7 @@ public class FlippingPanel extends JPanel
 					plugin.resetTradeHistory();
 					itemHighlighted = false;
 					cardLayout.show(getCenterPanel(), FlippingPanel.getWELCOME_PANEL());
-					rebuildFlippingPanel(plugin.getTrades());
+					updateDisplays(plugin.getTradesForCurrentView());
 				}
 			}
 
@@ -269,7 +269,7 @@ public class FlippingPanel extends JPanel
 		});
 	}
 
-	public void rebuildFlippingPanel(ArrayList<FlippingItem> flippingItems)
+	public void updateDisplays(ArrayList<FlippingItem> flippingItems)
 	{
 		flippingItemsPanel.removeAll();
 		if (flippingItems == null)
@@ -299,7 +299,7 @@ public class FlippingPanel extends JPanel
 		ArrayList<FlippingItem> itemToHighlight = new ArrayList<>(findItemPanel(itemId));
 		if (!itemToHighlight.isEmpty())
 		{
-			rebuildFlippingPanel(itemToHighlight);
+			updateDisplays(itemToHighlight);
 			itemHighlighted = true;
 		}
 	}
@@ -313,7 +313,7 @@ public class FlippingPanel extends JPanel
 			return;
 		}
 
-		rebuildFlippingPanel(plugin.getTrades());
+		updateDisplays(plugin.getTradesForCurrentView());
 		itemHighlighted = false;
 		plugin.setPrevHighlight(0);
 	}
@@ -322,7 +322,7 @@ public class FlippingPanel extends JPanel
 	{
 		ArrayList<FlippingItem> result = new ArrayList<>();
 
-		for (FlippingItem item : plugin.getTrades())
+		for (FlippingItem item : plugin.getTradesForCurrentView())
 		{
 			if (item.getItemId() == itemId)
 			{
@@ -371,10 +371,10 @@ public class FlippingPanel extends JPanel
 		{
 			return;
 		}
-		ArrayList<FlippingItem> tradeList = plugin.getTrades();
+		ArrayList<FlippingItem> tradeList = plugin.getTradesForCurrentView();
 		tradeList.remove(itemPanel.getFlippingItem());
 
-		rebuildFlippingPanel(tradeList);
+		updateDisplays(tradeList);
 		plugin.storeTradeHistory();
 	}
 
@@ -393,12 +393,12 @@ public class FlippingPanel extends JPanel
 		//When the clear button is pressed, this is run.
 		if (Strings.isNullOrEmpty(lookup))
 		{
-			rebuildFlippingPanel(plugin.getTrades());
+			updateDisplays(plugin.getTradesForCurrentView());
 			return;
 		}
 
 		ArrayList<FlippingItem> result = new ArrayList<>();
-		for (FlippingItem item : plugin.getTrades())
+		for (FlippingItem item : plugin.getTradesForCurrentView())
 		{
 			//Contains makes it a little more forgiving when searching.
 			if (item.getItemName().toLowerCase().contains(lookup))
@@ -411,12 +411,12 @@ public class FlippingPanel extends JPanel
 		{
 			searchBar.setIcon(IconTextField.Icon.ERROR);
 			searchBar.setEditable(true);
-			rebuildFlippingPanel(plugin.getTrades());
+			updateDisplays(plugin.getTradesForCurrentView());
 			return;
 		}
 
 		searchBar.setIcon(IconTextField.Icon.SEARCH);
-		rebuildFlippingPanel(result);
+		updateDisplays(result);
 	}
 
 }

--- a/src/main/java/com/flippingutilities/ui/flipping/FlippingPanel.java
+++ b/src/main/java/com/flippingutilities/ui/flipping/FlippingPanel.java
@@ -372,7 +372,7 @@ public class FlippingPanel extends JPanel
 		tradeList.remove(itemPanel.getFlippingItem());
 
 		rebuildFlippingPanel(tradeList);
-		plugin.updateConfig();
+		plugin.storeTradeHistory();
 	}
 
 	//Searches the active item panels for matching item names.

--- a/src/main/java/com/flippingutilities/ui/flipping/FlippingPanel.java
+++ b/src/main/java/com/flippingutilities/ui/flipping/FlippingPanel.java
@@ -375,7 +375,7 @@ public class FlippingPanel extends JPanel
 		tradeList.remove(itemPanel.getFlippingItem());
 
 		updateDisplays(tradeList);
-		plugin.storeTradeHistory();
+		plugin.storeTradeHistory(plugin.getCurrentView());
 	}
 
 	//Searches the active item panels for matching item names.

--- a/src/main/java/com/flippingutilities/ui/flipping/FlippingPanel.java
+++ b/src/main/java/com/flippingutilities/ui/flipping/FlippingPanel.java
@@ -177,7 +177,7 @@ public class FlippingPanel extends JPanel
 					plugin.resetTradeHistory();
 					itemHighlighted = false;
 					cardLayout.show(getCenterPanel(), FlippingPanel.getWELCOME_PANEL());
-					updateDisplays(plugin.getTradesForCurrentView());
+					rebuildFlippingPanel(plugin.getTradesForCurrentView());
 				}
 			}
 
@@ -269,7 +269,7 @@ public class FlippingPanel extends JPanel
 		});
 	}
 
-	public void updateDisplays(ArrayList<FlippingItem> flippingItems)
+	public void rebuildFlippingPanel(ArrayList<FlippingItem> flippingItems)
 	{
 		flippingItemsPanel.removeAll();
 		if (flippingItems == null)
@@ -299,7 +299,7 @@ public class FlippingPanel extends JPanel
 		ArrayList<FlippingItem> itemToHighlight = new ArrayList<>(findItemPanel(itemId));
 		if (!itemToHighlight.isEmpty())
 		{
-			updateDisplays(itemToHighlight);
+			rebuildFlippingPanel(itemToHighlight);
 			itemHighlighted = true;
 		}
 	}
@@ -313,7 +313,7 @@ public class FlippingPanel extends JPanel
 			return;
 		}
 
-		updateDisplays(plugin.getTradesForCurrentView());
+		rebuildFlippingPanel(plugin.getTradesForCurrentView());
 		itemHighlighted = false;
 		plugin.setPrevHighlight(0);
 	}
@@ -374,7 +374,7 @@ public class FlippingPanel extends JPanel
 		ArrayList<FlippingItem> tradeList = plugin.getTradesForCurrentView();
 		tradeList.remove(itemPanel.getFlippingItem());
 
-		updateDisplays(tradeList);
+		rebuildFlippingPanel(tradeList);
 		plugin.storeTradeHistory(plugin.getCurrentView());
 	}
 
@@ -393,7 +393,7 @@ public class FlippingPanel extends JPanel
 		//When the clear button is pressed, this is run.
 		if (Strings.isNullOrEmpty(lookup))
 		{
-			updateDisplays(plugin.getTradesForCurrentView());
+			rebuildFlippingPanel(plugin.getTradesForCurrentView());
 			return;
 		}
 
@@ -411,12 +411,12 @@ public class FlippingPanel extends JPanel
 		{
 			searchBar.setIcon(IconTextField.Icon.ERROR);
 			searchBar.setEditable(true);
-			updateDisplays(plugin.getTradesForCurrentView());
+			rebuildFlippingPanel(plugin.getTradesForCurrentView());
 			return;
 		}
 
 		searchBar.setIcon(IconTextField.Icon.SEARCH);
-		updateDisplays(result);
+		rebuildFlippingPanel(result);
 	}
 
 }

--- a/src/main/java/com/flippingutilities/ui/flipping/FlippingPanel.java
+++ b/src/main/java/com/flippingutilities/ui/flipping/FlippingPanel.java
@@ -175,6 +175,9 @@ public class FlippingPanel extends JPanel
 				if (SwingUtilities.isLeftMouseButton(e))
 				{
 					plugin.resetTradeHistory();
+					itemHighlighted = false;
+					cardLayout.show(getCenterPanel(), FlippingPanel.getWELCOME_PANEL());
+					rebuildFlippingPanel(plugin.getTrades());
 				}
 			}
 
@@ -310,7 +313,7 @@ public class FlippingPanel extends JPanel
 			return;
 		}
 
-		rebuildFlippingPanel(plugin.getTradesList());
+		rebuildFlippingPanel(plugin.getTrades());
 		itemHighlighted = false;
 		plugin.setPrevHighlight(0);
 	}
@@ -319,7 +322,7 @@ public class FlippingPanel extends JPanel
 	{
 		ArrayList<FlippingItem> result = new ArrayList<>();
 
-		for (FlippingItem item : plugin.getTradesList())
+		for (FlippingItem item : plugin.getTrades())
 		{
 			if (item.getItemId() == itemId)
 			{
@@ -368,7 +371,7 @@ public class FlippingPanel extends JPanel
 		{
 			return;
 		}
-		ArrayList<FlippingItem> tradeList = plugin.getTradesList();
+		ArrayList<FlippingItem> tradeList = plugin.getTrades();
 		tradeList.remove(itemPanel.getFlippingItem());
 
 		rebuildFlippingPanel(tradeList);
@@ -390,12 +393,12 @@ public class FlippingPanel extends JPanel
 		//When the clear button is pressed, this is run.
 		if (Strings.isNullOrEmpty(lookup))
 		{
-			rebuildFlippingPanel(plugin.getTradesList());
+			rebuildFlippingPanel(plugin.getTrades());
 			return;
 		}
 
 		ArrayList<FlippingItem> result = new ArrayList<>();
-		for (FlippingItem item : plugin.getTradesList())
+		for (FlippingItem item : plugin.getTrades())
 		{
 			//Contains makes it a little more forgiving when searching.
 			if (item.getItemName().toLowerCase().contains(lookup))
@@ -408,7 +411,7 @@ public class FlippingPanel extends JPanel
 		{
 			searchBar.setIcon(IconTextField.Icon.ERROR);
 			searchBar.setEditable(true);
-			rebuildFlippingPanel(plugin.getTradesList());
+			rebuildFlippingPanel(plugin.getTrades());
 			return;
 		}
 

--- a/src/main/java/com/flippingutilities/ui/statistics/StatisticsPanel.java
+++ b/src/main/java/com/flippingutilities/ui/statistics/StatisticsPanel.java
@@ -41,6 +41,7 @@ import java.text.DecimalFormatSymbols;
 import java.text.NumberFormat;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.concurrent.ScheduledExecutorService;
@@ -179,7 +180,7 @@ public class StatisticsPanel extends JPanel
 			}
 			//Handle new time interval selected
 			setTimeInterval(selectedInterval);
-			updateDisplays();
+			updateDisplays(plugin.getTradesForCurrentView());
 		});
 
 		//Holds the time interval selector beneath the tab manager.
@@ -352,7 +353,7 @@ public class StatisticsPanel extends JPanel
 	 * Gets called on startup, after the tradesList has been initialized and after every new registered trade.
 	 */
 	//New trade registered, updateHistoryAndTradedTime the profit labels and add/updateHistoryAndTradedTime profit item.
-	public void updateDisplays()
+	public void updateDisplays(ArrayList<FlippingItem> trades)
 	{
 		SwingUtilities.invokeLater(() ->
 		{
@@ -360,7 +361,7 @@ public class StatisticsPanel extends JPanel
 			totalExpenses = 0;
 			totalRevenues = 0;
 
-			for (FlippingItem item : plugin.getTrades())
+			for (FlippingItem item : trades)
 			{
 				totalProfit += item.currentProfit(startOfInterval);
 				totalExpenses += item.getTotalExpenses();
@@ -377,11 +378,11 @@ public class StatisticsPanel extends JPanel
 
 	/**
 	 * Responsible for updating the total profit label at the very top.
-	 * Sets the new total profit value from the items in tradesList from {@link FlippingPlugin#getTrades()}.
+	 * Sets the new total profit value from the items in tradesList from {@link FlippingPlugin#getTradesForCurrentView()}.
 	 */
 	private void updateTotalProfitDisplay()
 	{
-		if (plugin.getTrades() == null)
+		if (plugin.getTradesForCurrentView() == null)
 		{
 			totalProfitVal.setText("0");
 			totalProfitVal.setForeground(ColorScheme.GRAND_EXCHANGE_PRICE);

--- a/src/main/java/com/flippingutilities/ui/statistics/StatisticsPanel.java
+++ b/src/main/java/com/flippingutilities/ui/statistics/StatisticsPanel.java
@@ -150,7 +150,7 @@ public class StatisticsPanel extends JPanel
 	 *
 	 * @param plugin      Used to access the config and list of trades.
 	 * @param itemManager Accesses the RuneLite item cache.
-	 * @param executor    For repeated method calls, required by periodic update methods.
+	 * @param executor    For repeated method calls, required by periodic updateHistoryAndTradedTime methods.
 	 */
 	public StatisticsPanel(final FlippingPlugin plugin, final ItemManager itemManager, final ScheduledExecutorService executor)
 	{
@@ -348,10 +348,10 @@ public class StatisticsPanel extends JPanel
 	}
 
 	/**
-	 * Updates all profit labels on the stat panel using their respective update methods.
+	 * Updates all profit labels on the stat panel using their respective updateHistoryAndTradedTime methods.
 	 * Gets called on startup, after the tradesList has been initialized and after every new registered trade.
 	 */
-	//New trade registered, update the profit labels and add/update profit item.
+	//New trade registered, updateHistoryAndTradedTime the profit labels and add/updateHistoryAndTradedTime profit item.
 	public void updateDisplays()
 	{
 		SwingUtilities.invokeLater(() ->
@@ -360,7 +360,7 @@ public class StatisticsPanel extends JPanel
 			totalExpenses = 0;
 			totalRevenues = 0;
 
-			for (FlippingItem item : plugin.getTradesList())
+			for (FlippingItem item : plugin.getTrades())
 			{
 				totalProfit += item.currentProfit(startOfInterval);
 				totalExpenses += item.getTotalExpenses();
@@ -377,11 +377,11 @@ public class StatisticsPanel extends JPanel
 
 	/**
 	 * Responsible for updating the total profit label at the very top.
-	 * Sets the new total profit value from the items in tradesList from {@link FlippingPlugin#getTradesList()}.
+	 * Sets the new total profit value from the items in tradesList from {@link FlippingPlugin#getTrades()}.
 	 */
 	private void updateTotalProfitDisplay()
 	{
-		if (plugin.getTradesList() == null)
+		if (plugin.getTrades() == null)
 		{
 			totalProfitVal.setText("0");
 			totalProfitVal.setForeground(ColorScheme.GRAND_EXCHANGE_PRICE);


### PR DESCRIPTION
### High level overview of functionality:

A user can now track trades based on account. They can view the trades for all their accounts with a flip history through a dropdown menu:

<img width="249" alt="Screen Shot 2020-04-19 at 3 52 20 AM" src="https://user-images.githubusercontent.com/21697386/79699856-06c0ee80-8260-11ea-9d25-7667dafd4595.png">

Expanded:

<img width="245" alt="Screen Shot 2020-04-19 at 3 52 34 AM" src="https://user-images.githubusercontent.com/21697386/79699861-0c1e3900-8260-11ea-9541-b2dd695e41af.png">

When they click on an account's name they see that account's trades and any action they perform on those panels only changes that account's history. For example, if they delete a panel, it only deletes the flipping item from the account's history that they are currently viewing. Similarly, if they reset the history by clicking the reset button, it only clears the history of the account they are currently viewing. **These actions don't affect account wide history or any other account.**

On startup of the client, account wide history is loaded and displayed. Account wide history is an aggregation of the history from all accounts with a trade history. This is a convenient way to get a total profit value across all accounts. Along with loading and displaying account wide history, the dropdown menu is populated with the names of all accounts that have a flipping history, which a user can then select.

If a user has no accounts with a trade history yet, the dropdown menu still starts off with just account wide, but as soon as they log in it adds their username to the dropdown menu and creates their history. Subsequent client restarts will have that username already added to the menu, so you can switch between viewing trade lists even before logging in.

**Here is a video demonstrating the whole cycle, starting off with a fresh restart with absolutely no history for any account:**

https://youtu.be/PrcwBuZADy8.

Now, since the accounts have a history, even if I restart the client, I'll be able to automatically see their names on the dropdown and thus view their trades. Every time you log into an account, it will switch the view to that account's trade list.

Some important things not shown in the video:
1. If more than one account flips the same item, the account wide trade list will show separate items for those flips with a hover attribution to the account that flipped it. So for example, if two of my accounts flipped salmon, the account wide trade list would have two panels with salmon on it, but if you hovered over them, it would show flipped by: {account that flipped them} to differentiate the same item flipped on different accounts.

2. If a user is viewing the trades list of a different account than the one they are logged in with and they are currently getting offers on their logged in account, the view won't change. It will update the trades list of the **logged in** account (and the account wide trade list), but it won't change the view nor update the trade list that is being viewed **as its not the one the offers are for** (given that it's different than the logged in account). So only when the user wants to see their logged in account's trade list and selects that account from the dropdown will it actually switch the view. And since it had been updating the whole time, it will have all the trades even though those trades came In when the user was looking at a different account's trades list.

### Changes to the code to implement the functionality above:

1. FlippingItem: added another field called flippedBy. This refers to the account the flipped this item. This field is then accessed by flippingItemPanel to display the tooltip on hover that attributes the flippingItemPanel to a specific account.

2. TabManager: added a dropdown called viewSelector (the JcomboBox) above the tab group. I added a new jpanel called header that has a border layout. In the NORTH section I added the view selector and in the the CENTER section I added the tab group.  I also added an action listener on the viewSelector that passed the selected account name to a method on the flippingPlugin called changeView. To prevent flippingPlugin.changeView from being called when the same option in the dropdown was clicked as the currently selection option, I added a field in tabManager called prevSelectedUsername. As such, the FlippingPlugin.changeView is only called when the newly selected username is different than the previous one.

3. FlippingItemPanel: added tooltip text to each flipping panel that shows which account flipped that item. This is implemented by accessing the underlying FlippingItem's flippedBy field.

4. FlippingPanel: Since I renamed methods in FlippingPlugin, the invocations of them here changed. Also renamed rebuildFlippingPanel to updateDisplays cause that is essentially how we use it and it matches the name of the method in StatisticsPanel with a similar purpose.

5. StatisticsPanel: Since I renamed methods in FlippingPlugin, the invocations of them here changed. Made updateDisplays take in the arraylist of flipping items instead of calling plugin.getTradesForCurrentView() within the method body. This is so that it matches the updateDisplay in flippingPanel, thus making the api's for both our panels similar.

6. FlippingPlugin: This is where the meat of the change was. I'm going to break this up into several 
tasks below and explain it like that.

- storing different account's trade histories in a way that they can be differentiated.
- loading different account's trading history in memory in way that they can be differentiated and updated appropriately
- Maintaining and updating a global history and account specific history
- Handling changing views (looking at different trades list)
- Handling logins

### Storing different account's trade histories in a way that they can be differentiated:

We use the ConfigManager to persist trade history to a file. ConfigManager is made by the Runelite team and is what's typically used to store configs. To store things in config manager you provide it with a group, a key, and the value you want to store. It stores it in a file called settings.properties like so:
{GROUP_NAME}.{KEY}={VALUE},

So if I wanted to store trades for an account called giblert associated with the group "flipping", I would call ConfigManager.setConfiguration("flipping","giblert",JsonTradeList) and it would create something like this in the file:
flipping.gibert=[{item:123, ...},...]

The problem is that we have many keys associated with the group flipping. For example, we also stuff like flipping.storeTradeHistory=True.
So, just using "giblert" as a key isn't great because you can't look at the config manager and know which group and key pairs refer to a username (it doesn't know which key is a username or not). This is relevant because on startup of the client we want to populate the dropdown list with account names which have a flipping history, so that user can view their trade lists when they click on the name.

To solve this, I made every key that referred to an account's name be prefixed by the string "username:".

So, if I have account with a username of "Gilbert", its trades will be stored in the settings.properties as flipping.username:gilbert=[{item:123, ...},...]. Now, to fetch all the account usernames with a flipping history, we can fetch all the keys from the config manager and then find the ones that start with "username:".

Likewise, to fetch a specific account's trade history, given we have access to its username, we can just do ConfigManager.getConfiguration("flipping", "username:" + actual_username).

That's for trade lists associated with a specific account. The account wide trade list is stored In settings.properties like so:
flipping.accountwide=[{item:123, ...},...]

**To sum it up, every account has it trading list stored in a separate key which is a concatenation of "username:" + {account_username}, so that it can be loaded individually and updated individually.**

### Loading different account's trading history from disk into memory in way that they can be differentiated and updated appropriately (updating the correct trade list):

Because a user can have multiple accounts, and can be looking at different trades lists than the currently logged in account, it's crucial to be able to differentiate trades lists and update the correct one.

To do this, I created a hash map which maps username to tradelist. This is stored in a field of the FlippingPlugin called ```private Map<String, ArrayList<FlippingItem>> userTradelistCache = new HashMap<>();```.

When the client is first started, it loads the account wide history and displays it. It also gets all the usernames that have a flipping history and adds them to the dropdown so that a user can potentially select one. **Thus, on startup, it does not load any account specific trade data**.

As such, the ```userTradeListCache``` can get populated in two ways: when the user logs in with an account, or when the user selects an account name from the dropdown menu.

When the user logs into an account, if there isn't already data for that account in the cache, it loads the trade data for that account from disk and sets it in the cache associated with the account's username. 

When the user selects a username from the dropdown menu, it goes through the same process. If the data for that username is already in the cache, it gets it and displays it. Otherwise, it loads the trade data for that account from disk, sets it by putting it in the cache and associating it with the username, and then displays it.

**The plugin heavily depends on this cache and uses it every time it wants to access a user specific trades list**. This can happen when updating a trade lists (you want the trade list associated with the currently logged in user), or when hitting the reset button on the flipping panel (it needs to know which account's trade list the user is currently looking at and then get that corresponding username's trade list from the cache, etc). Essentially, every time an operation is done on an account specific trade list, the trade list is retrieved from the cache.

**To sum it up, the ```userTradelistCache``` is a way to associate a username to its trading history so that it can be updated when it needs to be.**


**Maintaining and updating a global history and account specific history:**

The account wide history is not stored in the cache, it's stored in a field called ```accountWideTrades``` in the FlippingPlugin. Both account wide history and user specific history are updated in OnGrandExchangeOfferChanged, with calls to UpdateTradesList which has 3 arguments: the trade list to be updated, the item that the offer is for, and the OfferInfo object. There are two key difference between how the user specific trade list is updated and how the account wide trade list is updated. 

One, the user trade list is passed to UpdateTradeList by accessing the cache and getting the trade list associated with the currently logged in user, whereas the account wide trade list is just accessed from the field ```accountWideTrades```.

Two, the process for finding the FlippingItem the the offer is for is different, depending on whether you are searching in the account wide trade list or the user specific trade list. With account specific trade list there are only unique FlippingItems and as such to find the FlippingItem the offer is referring to, you just have to compare item ids. With the account wide trade list, because multiple accounts could have done the same item, you have to find the correct FlippingItem by comparing ids AND usernames (which is in the flippedBy field of a FlippingItem).

**To sum it up, every time we get an offer event in OnGrandExchangeOfferChanged, the trade list of the currently logged in user is updated and the account wide trade list is updated.**

### Handling changing views (looking at different trades list)

This is the functionality handled by a method in FlippingPlugin called ```ChangeView(String username)```. It is the action listener for the dropdown menu and is passed the username that the user clicked on. 

It looks at the username it was given and checks if it is in the ```userTradelistCache```. If it is, it gets the trade list. Otherwise, it loads the trade list from disk and put its in the cache mapping it the username. After it gets the trades list it displays it, and sets the ```currentView=username```, where username is the username it was passed.

**currentView is an  important field of FlippingPlugin**.  currentView is the username of the account whose trade list the user is currently looking at. It's used in FlippingPanel and StatisticsPanel as they need to know what trade list is currently being looked at to handle things like highlighting items, deleting items and updating themselves. For example, if a user is currently looking at gilbert1's trade list and deletes a FlippingItemPanel, gilbert1's trade list should have the item removed not gilbert2. 

It's also used in FlippingPlugin to ensure that the displays are only updated on a received offer if the user is currently looking at that account's trade list. Otherwise, there isn't a need to update the display the trade list the user is looking at isn't the trade list being updated.

**To sum it up, when a user clicks on the dropdown, a username is provided to changeView. changeView changes the displays to reflect the trades list associated with that username either by loading it from disk or getting it from the cache if it's there.**

### Handling logins:

Login is handled in ```onGameStateChanged``` as you can see if the event you get is == to the LOGGED_IN game state.

When a user logs in, we set the ```loggedInUser``` like so ```loggedInUser = client.getUsername();```. Then, we check to see if the account has a flipping history. This is done by checking if the username Is in the set returned by ```getAccountNames()```.  ```getAccountNames``` simply gets all the keys from the config manager and sees which ones are usernames and then extracts the actual username from them and puts them in a set.

If the username is not in the set, it means that account has no flipping history, so we set a blank history for it like so  ```configManager.setConfiguration(CONFIG_GROUP, KEY_PREFIX + loggedInUser, new Gson().toJson(new ArrayList<>())):```


and we add the name to the dropdown menu.

We also check to see if that username has any data associated In the cache (if it had no flipping history it doesn't but even if it did it may have not been loaded into the cache yet). If it doesn't have data associated with it in the cache, we load it from disk and set the cache.

Finally, we set the selected item on the dropdown: ```	tabManager.getViewSelector().setSelectedItem(loggedInUser);``` and set ```				currentView = loggedInUser;```.
Setting the dropdown's selected item automatically fires its action listener, which calls change view, which then updates the display.

**To sum it up, logging in creates a blank history for the account if there currently isn't any, loads the data to the cache if there isn't any already, and updates the display to reflect the trade list of the account that just logged in.**

