### PR TITLE
stopped submitting storeTrades as a task to executor

### DIFF
--- a/src/main/java/com/flippingutilities/FlippingPlugin.java
+++ b/src/main/java/com/flippingutilities/FlippingPlugin.java
@@ -195,10 +195,12 @@ public class FlippingPlugin extends Plugin
 
 					flippingPanel.rebuild(tradesList);
 					String lastSelectedInterval = configManager.getConfiguration(CONFIG_GROUP, TIME_INTERVAL_CONFIG_KEY);
-					if (lastSelectedInterval == null) {
+					if (lastSelectedInterval == null)
+					{
 						statPanel.setTimeInterval("All", true);
 					}
-					else {
+					else
+					{
 						statPanel.setTimeInterval(lastSelectedInterval, true);
 					}
 
@@ -229,11 +231,7 @@ public class FlippingPlugin extends Plugin
 	public void onClientShutdown(ClientShutdown clientShutdownEvent)
 	{
 		log.info("Shutting down, saving trades!");
-
-		Future<Void> storeTradeTaskStatus = storeTrades(tradesList);
-
-		clientShutdownEvent.waitFor(storeTradeTaskStatus);
-
+		storeTrades(tradesList);
 	}
 
 	@Subscribe
@@ -521,23 +519,17 @@ public class FlippingPlugin extends Plugin
 	 * @param trades user's trade list
 	 * @return a future that can be queried to figure out whether the task has been completed.
 	 */
-	public Future<Void> storeTrades(List<FlippingItem> trades)
+	public void storeTrades(List<FlippingItem> trades)
 	{
-		Future<Void> tradeStoringTask = executor.submit(() -> {
-			try
-			{
-				tradePersister.storeTrades(trades);
-				log.info("successfully stored trades");
-			}
-			catch (IOException e)
-			{
-				log.info("couldn't store trades, error = " + e);
-			}
-			;
-			return null;
-		});
-
-		return tradeStoringTask;
+		try
+		{
+			tradePersister.storeTrades(trades);
+			log.info("successfully stored trades");
+		}
+		catch (IOException e)
+		{
+			log.info("couldn't store trades, error = " + e);
+		}
 	}
 
 	public List<FlippingItem> loadTrades()


### PR DESCRIPTION
stopped submitting storeTrades as a task to executor as it doesn't matter if it blocks the main thread. This is because we only call it when the client is shutting down (we want it to block the main thread in this case so that it finishes storing threads before shutting down the client) and on logout, in which case nothing new is being processed so its ok that the main thread is blocked.