### PR TITLE
Merging multi acc

### DIFF
--- a/src/main/java/com/flippingutilities/FlippingConfig.java
+++ b/src/main/java/com/flippingutilities/FlippingConfig.java
@@ -112,4 +112,15 @@ public interface FlippingConfig extends Config
 	{
 		return Fonts.SMALL_FONT;
 	}
+
+	@ConfigItem(
+		keyName = "multiAccTracking",
+		name = "multi account tracking",
+		description = "Enabling this feature gives you access to a dropdown which allows you to see each of your accounts" +
+			"flips and profits in isolation. This is very useful if you flip on multiple accounts."
+	)
+	default boolean multiAccTracking()
+	{
+		return false;
+	}
 }

--- a/src/main/java/com/flippingutilities/FlippingItem.java
+++ b/src/main/java/com/flippingutilities/FlippingItem.java
@@ -101,11 +101,16 @@ public class FlippingItem
 	@SerializedName("h")
 	private HistoryManager history = new HistoryManager();
 
-	public FlippingItem(int itemId, String itemName, int totalGeLimit)
+	@SerializedName("fB")
+	@Getter
+	private String flippedBy;
+
+	public FlippingItem(int itemId, String itemName, int totalGeLimit, String flippedBy)
 	{
 		this.itemId = itemId;
 		this.itemName = itemName;
 		this.totalGELimit = totalGeLimit;
+		this.flippedBy = flippedBy;
 	}
 
 	/**

--- a/src/main/java/com/flippingutilities/TradePersister.java
+++ b/src/main/java/com/flippingutilities/TradePersister.java
@@ -4,11 +4,12 @@ import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import java.io.File;
 import java.io.IOException;
-import java.io.PrintWriter;
 import java.lang.reflect.Type;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.client.RuneLite;
 
@@ -60,35 +61,36 @@ public class TradePersister
 	}
 
 	/**
-	 * Loads the json as a byte array, converts it into a string, then converts it into flipping
-	 * items. If there is no previous trades stores, it just returns an empty arraylist.
+	 * Loads the json as a byte array, converts it into a string, then converts it into hashmap
+	 * that associated a display name to an arraylist of flipping items. If there is no previous trades
+	 * stored, it just returns an empty hashmap.
 	 *
-	 * @return the user's previous trades
-	 * @throws IOException to be handled in flipping plugin
+	 * @return all of user's accounts' trades.
+	 * @throws IOException handled in flipping plugin
 	 */
-	public List<FlippingItem> loadTrades() throws IOException
+	public Map<String,List<FlippingItem>> loadTrades() throws IOException
 	{
 		String tradesJson = new String(Files.readAllBytes(TRADE_DATA_FILE.toPath()));
 
 		final Gson gson = new Gson();
-		Type type = new TypeToken<ArrayList<FlippingItem>>()
+		Type type = new TypeToken<Map<String,ArrayList<FlippingItem>>>()
 		{
 		}.getType();
-		List<FlippingItem> trades = gson.fromJson(tradesJson, type);
+		Map<String,List<FlippingItem>> trades = gson.fromJson(tradesJson, type);
 
-		return trades == null ? new ArrayList<>() : trades;
+		return trades == null ? new HashMap<>() : trades;
 	}
 
 	/**
 	 * Stores the user's trades in a file located at {user's home directory}/.runelite/flipping/trades.json
 	 *
-	 * @param trades the user's trades
-	 * @throws IOException to be handled in flipping plugin
+	 * @param tradesCache all of user's accounts' trades.
+	 * @throws IOException handled in flipping plugin
 	 */
-	public void storeTrades(List<FlippingItem> trades) throws IOException
+	public void storeTrades(Map<String,List<FlippingItem>> tradesCache) throws IOException
 	{
 		final Gson gson = new Gson();
-		final String json = gson.toJson(trades);
+		final String json = gson.toJson(tradesCache);
 		TRADE_DATA_FILE.delete();
 		TRADE_DATA_FILE.createNewFile();
 		Files.write(TRADE_DATA_FILE.toPath(), json.getBytes());

--- a/src/main/java/com/flippingutilities/ui/TabManager.java
+++ b/src/main/java/com/flippingutilities/ui/TabManager.java
@@ -29,16 +29,27 @@ package com.flippingutilities.ui;
 import com.flippingutilities.ui.flipping.FlippingPanel;
 import com.flippingutilities.ui.statistics.StatsPanel;
 import java.awt.BorderLayout;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.function.Consumer;
+import java.util.function.Function;
 import javax.inject.Inject;
+import javax.swing.JComboBox;
 import javax.swing.JPanel;
 import javax.swing.border.EmptyBorder;
+import lombok.Getter;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.PluginPanel;
+import net.runelite.client.ui.components.ComboBoxListRenderer;
 import net.runelite.client.ui.components.materialtabs.MaterialTab;
 import net.runelite.client.ui.components.materialtabs.MaterialTabGroup;
 
 public class TabManager extends PluginPanel
 {
+	@Getter
+	private JComboBox<String> viewSelector = new JComboBox();
+
+	private String prevSelectedUsername;
 
 	/**
 	 * This manages the tab navigation bar at the top of the panel.
@@ -49,14 +60,42 @@ public class TabManager extends PluginPanel
 	 * @param statPanel     StatPanel represents useful performance statistics to the user.
 	 */
 	@Inject
-	public TabManager(FlippingPanel flippingPanel, StatsPanel statPanel)
+	public TabManager(Consumer<String> viewChangerMethod, FlippingPanel flippingPanel, StatsPanel statPanel)
 	{
 		super(false);
 
 		setLayout(new BorderLayout());
 		setBackground(ColorScheme.DARKER_GRAY_COLOR.darker());
 
+		viewSelector.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		viewSelector.setFocusable(false);
+		viewSelector.setForeground(ColorScheme.GRAND_EXCHANGE_PRICE);
+		viewSelector.setRenderer(new ComboBoxListRenderer());
+		viewSelector.setToolTipText("select which of your account's trades list you want to view");
+		viewSelector.addActionListener(event ->
+		{
+			String selectedUsername = (String) viewSelector.getSelectedItem();
+
+			if (selectedUsername == null)
+			{
+				return;
+			}
+
+			if (!selectedUsername.equals(prevSelectedUsername) || prevSelectedUsername == null)
+			{
+				prevSelectedUsername = selectedUsername;
+				viewChangerMethod.accept(selectedUsername);
+			}
+		});
+
 		JPanel display = new JPanel();
+		//contains the tab group and the view selector combo box.
+		JPanel header = new JPanel(new BorderLayout());
+
+		header.setBackground(ColorScheme.DARKER_GRAY_COLOR.darker());
+		header.setBorder(new EmptyBorder(5, 0, 0, 0));
+		header.add(viewSelector, BorderLayout.NORTH);
+
 		MaterialTabGroup tabGroup = new MaterialTabGroup(display);
 		MaterialTab flippingTab = new MaterialTab("Flipping", tabGroup, flippingPanel);
 		MaterialTab statTab = new MaterialTab("Statistics", tabGroup, statPanel);
@@ -68,7 +107,10 @@ public class TabManager extends PluginPanel
 		// Initialize with flipping tab open.
 		tabGroup.select(flippingTab);
 
-		add(tabGroup, BorderLayout.NORTH);
+		header.add(tabGroup, BorderLayout.CENTER);
+
+		add(header, BorderLayout.NORTH);
 		add(display, BorderLayout.CENTER);
 	}
+
 }

--- a/src/main/java/com/flippingutilities/ui/TabManager.java
+++ b/src/main/java/com/flippingutilities/ui/TabManager.java
@@ -29,6 +29,7 @@ package com.flippingutilities.ui;
 import com.flippingutilities.ui.flipping.FlippingPanel;
 import com.flippingutilities.ui.statistics.StatsPanel;
 import java.awt.BorderLayout;
+import java.awt.event.ItemEvent;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.function.Consumer;
@@ -48,8 +49,6 @@ public class TabManager extends PluginPanel
 {
 	@Getter
 	private JComboBox<String> viewSelector = new JComboBox();
-
-	private String prevSelectedUsername;
 
 	/**
 	 * This manages the tab navigation bar at the top of the panel.
@@ -72,19 +71,16 @@ public class TabManager extends PluginPanel
 		viewSelector.setForeground(ColorScheme.GRAND_EXCHANGE_PRICE);
 		viewSelector.setRenderer(new ComboBoxListRenderer());
 		viewSelector.setToolTipText("select which of your account's trades list you want to view");
-		viewSelector.addActionListener(event ->
-		{
-			String selectedUsername = (String) viewSelector.getSelectedItem();
+		viewSelector.addItemListener(event -> {
+			if (event.getStateChange() == ItemEvent.SELECTED) {
 
-			if (selectedUsername == null)
-			{
-				return;
-			}
+				String selectedDisplayName = (String) event.getItem();
 
-			if (!selectedUsername.equals(prevSelectedUsername) || prevSelectedUsername == null)
-			{
-				prevSelectedUsername = selectedUsername;
-				viewChangerMethod.accept(selectedUsername);
+				if (selectedDisplayName == null) {
+					return;
+				} else {
+					viewChangerMethod.accept(selectedDisplayName);
+				}
 			}
 		});
 

--- a/src/main/java/com/flippingutilities/ui/flipping/FlippingItemPanel.java
+++ b/src/main/java/com/flippingutilities/ui/flipping/FlippingItemPanel.java
@@ -273,6 +273,7 @@ public class FlippingItemPanel extends JPanel
 		updateGePropertiesDisplay();
 		updatePriceOutdatedDisplay();
 
+		setToolTipText("flipped by " + flippingItem.getFlippedBy());
 		add(titlePanel, BorderLayout.NORTH);
 		add(itemInfo, BorderLayout.CENTER);
 	}

--- a/src/main/java/com/flippingutilities/ui/flipping/FlippingPanel.java
+++ b/src/main/java/com/flippingutilities/ui/flipping/FlippingPanel.java
@@ -65,6 +65,8 @@ import net.runelite.client.ui.PluginPanel;
 import net.runelite.client.ui.components.IconTextField;
 import net.runelite.client.ui.components.PluginErrorPanel;
 
+
+
 @Slf4j
 public class FlippingPanel extends JPanel
 {
@@ -232,65 +234,63 @@ public class FlippingPanel extends JPanel
 		//Reset active panel list.
 		activePanels.clear();
 
-		SwingUtilities.invokeLater(() ->
+
+		cardLayout.show(centerPanel, ITEMS_PANEL);
+
+		int index = 0;
+		for (FlippingItem item : flippingItems)
 		{
-			cardLayout.show(centerPanel, ITEMS_PANEL);
-
-			int index = 0;
-			for (FlippingItem item : flippingItems)
+			if (!item.hasValidOffers(HistoryManager.PanelSelection.FLIPPING))
 			{
-				if (!item.hasValidOffers(HistoryManager.PanelSelection.FLIPPING))
-				{
-					continue;
-				}
+				continue;
+			}
 
-				FlippingItemPanel newPanel = new FlippingItemPanel(plugin, itemManager, item);
+			FlippingItemPanel newPanel = new FlippingItemPanel(plugin, itemManager, item);
 
-				newPanel.clearButton.addMouseListener(new MouseAdapter()
+			newPanel.clearButton.addMouseListener(new MouseAdapter()
+			{
+				@Override
+				public void mouseClicked(MouseEvent e)
 				{
-					@Override
-					public void mouseClicked(MouseEvent e)
+					if (e.getButton() == MouseEvent.BUTTON1)
 					{
-						if (e.getButton() == MouseEvent.BUTTON1)
-						{
-							deleteItemPanel(newPanel);
-							rebuild(plugin.getTradesForCurrentView());
-						}
+						deleteItemPanel(newPanel);
+						rebuild(plugin.getTradesForCurrentView());
 					}
-				});
-
-				if (index++ > 0)
-				{
-					JPanel marginWrapper = new JPanel(new BorderLayout());
-					marginWrapper.setBackground(ColorScheme.DARK_GRAY_COLOR);
-					marginWrapper.setBorder(new EmptyBorder(4, 0, 0, 0));
-					marginWrapper.add(newPanel, BorderLayout.NORTH);
-					flippingItemsPanel.add(marginWrapper, constraints);
 				}
-				else
-				{
-					flippingItemsPanel.add(newPanel, constraints);
-				}
-				constraints.gridy++;
-				activePanels.add(newPanel);
-			}
+			});
 
-			if (activePanels.isEmpty())
+			if (index++ > 0)
 			{
-				cardLayout.show(centerPanel, WELCOME_PANEL);
+				JPanel marginWrapper = new JPanel(new BorderLayout());
+				marginWrapper.setBackground(ColorScheme.DARK_GRAY_COLOR);
+				marginWrapper.setBorder(new EmptyBorder(4, 0, 0, 0));
+				marginWrapper.add(newPanel, BorderLayout.NORTH);
+				flippingItemsPanel.add(marginWrapper, constraints);
 			}
-		});
+			else
+			{
+				flippingItemsPanel.add(newPanel, constraints);
+			}
+			constraints.gridy++;
+			activePanels.add(newPanel);
+		}
+
+		if (activePanels.isEmpty())
+		{
+			cardLayout.show(centerPanel, WELCOME_PANEL);
+		}
 
 	}
 
 	public void rebuild(List<FlippingItem> flippingItems)
 	{
 		flippingItemsPanel.removeAll();
-
-		initializeFlippingPanel(flippingItems);
-
-		revalidate();
-		repaint();
+		SwingUtilities.invokeLater(() -> {
+			initializeFlippingPanel(flippingItems);
+			revalidate();
+			repaint();
+		});
 	}
 
 	@Getter
@@ -353,11 +353,11 @@ public class FlippingPanel extends JPanel
 	/**
 	 * uses the properties of the FlippingItem to show the ge limit and refresh time display. This is invoked
 	 * in the FlippingPlugin in two places:
-	 *
+	 * <p>
 	 * 1. Everytime an offer comes in (in onGrandExchangeOfferChanged) and the user
-	 *    is currently looking at either the account wide trade list or trades list of the account currently
-	 *    logged in
-	 *
+	 * is currently looking at either the account wide trade list or trades list of the account currently
+	 * logged in
+	 * <p>
 	 * 2. In a background thread every second, as initiated in the startUp() method of the FlippingPlugin.
 	 */
 	public void updateActivePanelsGePropertiesDisplay()

--- a/src/main/java/com/flippingutilities/ui/flipping/FlippingPanel.java
+++ b/src/main/java/com/flippingutilities/ui/flipping/FlippingPanel.java
@@ -170,7 +170,7 @@ public class FlippingPanel extends JPanel
 				{
 					resetPanel();
 					cardLayout.show(centerPanel, FlippingPanel.getWELCOME_PANEL());
-					rebuild(plugin.getTradesList());
+					rebuild(plugin.getTradesForCurrentView());
 				}
 			}
 
@@ -191,7 +191,7 @@ public class FlippingPanel extends JPanel
 		clearMenuOption.addActionListener(e ->
 		{
 
-			plugin.getTradesList().clear();
+			plugin.getTradesForCurrentView().clear();
 			resetPanel();
 			plugin.getStatPanel().resetPanel();
 		});
@@ -254,7 +254,7 @@ public class FlippingPanel extends JPanel
 						if (e.getButton() == MouseEvent.BUTTON1)
 						{
 							deleteItemPanel(newPanel);
-							rebuild(plugin.getTradesList());
+							rebuild(plugin.getTradesForCurrentView());
 						}
 					}
 				});
@@ -323,7 +323,7 @@ public class FlippingPanel extends JPanel
 			return;
 		}
 
-		rebuild(plugin.getTradesList());
+		rebuild(plugin.getTradesForCurrentView());
 		itemHighlighted = false;
 		plugin.setPrevHighlight(0);
 	}
@@ -331,12 +331,13 @@ public class FlippingPanel extends JPanel
 	public ArrayList<FlippingItem> findItemPanel(int itemId)
 	{
 		//We only expect one item.
-		return plugin.getTradesList().stream()
+		return plugin.getTradesForCurrentView().stream()
 			.filter(item -> item.getItemId() == itemId && item.hasValidOffers(HistoryManager.PanelSelection.FLIPPING))
 			.collect(Collectors.toCollection(ArrayList::new));
 	}
 
 	//Updates tooltips on prices to show how long ago the latest margin check was.
+
 	/**
 	 * Checks if a FlippingItem's margins (buy and sell price) are outdated and updates the tooltip.
 	 * This method is called in FlippingPLugin every second by the scheduler.
@@ -351,8 +352,13 @@ public class FlippingPanel extends JPanel
 
 	/**
 	 * uses the properties of the FlippingItem to show the ge limit and refresh time display. This is invoked
-	 * in the FlippingPlugin in two places: Everytime an offer comes in (in onGrandExchangeOfferChanged) and
-	 * in a background thread every second, as initiated in the startUp() method of the FlippingPlugin.
+	 * in the FlippingPlugin in two places:
+	 *
+	 * 1. Everytime an offer comes in (in onGrandExchangeOfferChanged) and the user
+	 *    is currently looking at either the account wide trade list or trades list of the account currently
+	 *    logged in
+	 *
+	 * 2. In a background thread every second, as initiated in the startUp() method of the FlippingPlugin.
 	 */
 	public void updateActivePanelsGePropertiesDisplay()
 	{
@@ -398,12 +404,12 @@ public class FlippingPanel extends JPanel
 		//When the clear button is pressed, this is run.
 		if (Strings.isNullOrEmpty(lookup))
 		{
-			rebuild(plugin.getTradesList());
+			rebuild(plugin.getTradesForCurrentView());
 			return;
 		}
 
 		ArrayList<FlippingItem> result = new ArrayList<>();
-		for (FlippingItem item : plugin.getTradesList())
+		for (FlippingItem item : plugin.getTradesForCurrentView())
 		{
 			//Contains makes it a little more forgiving when searching.
 			if (item.getItemName().toLowerCase().contains(lookup))
@@ -416,7 +422,7 @@ public class FlippingPanel extends JPanel
 		{
 			searchBar.setIcon(IconTextField.Icon.ERROR);
 			searchBar.setEditable(true);
-			rebuild(plugin.getTradesList());
+			rebuild(plugin.getTradesForCurrentView());
 			return;
 		}
 

--- a/src/main/java/com/flippingutilities/ui/statistics/StatItemPanel.java
+++ b/src/main/java/com/flippingutilities/ui/statistics/StatItemPanel.java
@@ -206,7 +206,7 @@ public class StatItemPanel extends JPanel
 			public void mousePressed(MouseEvent e)
 			{
 				deletePanel();
-				statsPanel.rebuild(plugin.getTradesList());
+				statsPanel.rebuild(plugin.getTradesForCurrentView());
 			}
 
 			@Override

--- a/src/main/java/com/flippingutilities/ui/statistics/StatItemPanel.java
+++ b/src/main/java/com/flippingutilities/ui/statistics/StatItemPanel.java
@@ -44,7 +44,6 @@ import java.awt.event.MouseEvent;
 import java.awt.image.BufferedImage;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.concurrent.ScheduledExecutorService;
 import javax.swing.BorderFactory;
 import javax.swing.ImageIcon;
 import javax.swing.JLabel;
@@ -78,7 +77,6 @@ public class StatItemPanel extends JPanel
 		BorderFactory.createEmptyBorder(3, 5, 3, 5));
 
 	private FlippingPlugin plugin;
-	private ScheduledExecutorService executor;
 	@Getter
 	private FlippingItem flippingItem;
 

--- a/src/main/java/com/flippingutilities/ui/statistics/StatsPanel.java
+++ b/src/main/java/com/flippingutilities/ui/statistics/StatsPanel.java
@@ -226,7 +226,7 @@ public class StatsPanel extends JPanel
 				if (SwingUtilities.isLeftMouseButton(e))
 				{
 					resetPanel();
-					rebuild(plugin.getTradesList());
+					rebuild(plugin.getTradesForCurrentView());
 				}
 			}
 
@@ -247,7 +247,7 @@ public class StatsPanel extends JPanel
 		final JMenuItem clearMenuOption = new JMenuItem("Reset all panels");
 		clearMenuOption.addActionListener(e ->
 		{
-			plugin.getTradesList().clear();
+			plugin.getTradesForCurrentView().clear();
 			resetPanel();
 			plugin.getFlippingPanel().resetPanel();
 		});
@@ -395,7 +395,7 @@ public class StatsPanel extends JPanel
 				return;
 			}
 
-			rebuild(plugin.getTradesList());
+			rebuild(plugin.getTradesForCurrentView());
 		});
 
 		sortPanel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
@@ -504,7 +504,7 @@ public class StatsPanel extends JPanel
 		totalQuantity = 0;
 		totalFlips = 0;
 
-		List<FlippingItem> tradesList = plugin.getTradesList();
+		List<FlippingItem> tradesList = plugin.getTradesForCurrentView();
 
 		for (FlippingItem item : tradesList)
 		{
@@ -547,11 +547,11 @@ public class StatsPanel extends JPanel
 
 	/**
 	 * Responsible for updating the total profit label at the very top.
-	 * Sets the new total profit value from the items in tradesList from {@link FlippingPlugin#getTradesList()}.
+	 * Sets the new total profit value from the items in tradesList from {@link FlippingPlugin#getTradesForCurrentView()}.
 	 */
 	private void updateTotalProfitDisplay()
 	{
-		if (plugin.getTradesList() == null)
+		if (plugin.getTradesForCurrentView() == null)
 		{
 			totalProfitVal.setText("0");
 			totalProfitVal.setForeground(ColorScheme.GRAND_EXCHANGE_PRICE);
@@ -764,7 +764,7 @@ public class StatsPanel extends JPanel
 
 		if (!isStartUp)
 		{
-			rebuild(plugin.getTradesList());
+			rebuild(plugin.getTradesForCurrentView());
 		}
 	}
 


### PR DESCRIPTION
Finished merging multi acc functionality.

overview of changes:
1. config option to enable/disable multi acc tracking
2. flippingItem has a flippedBy attribute
3. history is now stored as a map that associates display name to a trade list (list of FlippingItem)
4. tab manager now has a dropdown menu that allows you to select different accounts to view.
5. There is an account wide trades list that aggregates trades from all accounts (this is also viewable through the dropdown)
6. new offers now update both the account wide trade list and the trade list of the account currently logged in.

