### PR TITLE
Fixing a few issues (v1.3.1)

### DIFF
--- a/src/main/java/com/flippingutilities/ui/flipping/FlippingItemPanel.java
+++ b/src/main/java/com/flippingutilities/ui/flipping/FlippingItemPanel.java
@@ -420,17 +420,17 @@ public class FlippingItemPanel extends JPanel
 	public void updateGePropertiesDisplay()
 	{
 		flippingItem.validateGeProperties();
+		boolean unknownLimit = false;
 
 		//New items can show as having a total GE limit of 0.
-		if (flippingItem.getTotalGELimit() != 0)
+		if (flippingItem.getTotalGELimit() > 0)
 		{
 			limitLabel.setText("GE limit: " + String.format(NUM_FORMAT, flippingItem.remainingGeLimit()));
 		}
 		else
 		{
-			limitLabel.setText("GE limit: ???");
-			limitLabel.setToolTipText("This item does not have a total GE limit.");
-			return;
+			limitLabel.setText("GE limit: Unknown");
+			unknownLimit = true;
 		}
 
 		if (flippingItem.getGeLimitResetTime() == null)
@@ -439,17 +439,24 @@ public class FlippingItemPanel extends JPanel
 		}
 		else
 		{
-			final long remainingSeconds =
-				flippingItem.getGeLimitResetTime().getEpochSecond() - Instant.now().getEpochSecond();
+			final long remainingSeconds = flippingItem.getGeLimitResetTime().getEpochSecond() - Instant.now().getEpochSecond();
 			final long remainingMinutes = remainingSeconds / 60 % 60;
 			final long remainingHours = remainingSeconds / 3600 % 24;
-			String timeString =
-				String.format("%02d:%02d ", remainingHours, remainingMinutes) + (remainingHours > 1
-					? "hours" : "hour");
+			String timeString = String.format("%02d:%02d ", remainingHours, remainingMinutes)
+				+ (remainingHours > 1 ? "hours" : "hour");
 
-			limitLabel.setToolTipText("<html>" + "GE limit is reset in " + timeString + "."
+			String tooltipText = "";
+
+			if (unknownLimit)
+			{
+				tooltipText = "<html>This item's total GE limit is unknown.<br>";
+			}
+
+			tooltipText += "<html>GE limit is reset in " + timeString + "."
 				+ "<br>This will be at " + UIUtilities.formatTime(flippingItem.getGeLimitResetTime(), plugin.getConfig().twelveHourFormat(), false)
-				+ ".<html>");
+				+ ".</html>";
+
+			limitLabel.setToolTipText(tooltipText);
 		}
 	}
 }

--- a/src/main/java/com/flippingutilities/ui/flipping/FlippingItemPanel.java
+++ b/src/main/java/com/flippingutilities/ui/flipping/FlippingItemPanel.java
@@ -298,7 +298,7 @@ public class FlippingItemPanel extends JPanel
 
 		profitEachVal.setText((buyPrice == 0 || sellPrice == 0) ? "N/A"
 			: QuantityFormatter.quantityToRSDecimalStack(profitEach) + " gp");
-		profitTotalVal.setText((buyPrice == 0 || sellPrice == 0) ? "N/A" : QuantityFormatter
+		profitTotalVal.setText((buyPrice == 0 || sellPrice == 0 || profitTotal < 0) ? "N/A" : QuantityFormatter
 			.quantityToRSDecimalStack(profitTotal) + " gp");
 
 		roiLabel.setText("ROI:  " + ((buyPrice == 0 || sellPrice == 0 || profitEach <= 0) ? "N/A"
@@ -334,24 +334,23 @@ public class FlippingItemPanel extends JPanel
 	//Recalculates profits.
 	public void updatePotentialProfit()
 	{
-		this.profitEach = sellPrice - buyPrice;
+		profitEach = sellPrice - buyPrice;
 
 		/*
 		If the user wants, we calculate the total profit while taking into account
 		the margin check loss. */
 		if (plugin.getConfig().geLimitProfit())
 		{
-			this.profitTotal = (flippingItem.remainingGeLimit() == 0) ? 0
+			profitTotal = (flippingItem.remainingGeLimit() == 0) ? 0
 				: flippingItem.remainingGeLimit() * profitEach - (plugin.getConfig().marginCheckLoss()
 				? profitEach : 0);
 		}
 		else
 		{
-			this.profitTotal =
-				flippingItem.getTotalGELimit() * profitEach - (plugin.getConfig().marginCheckLoss()
-					? profitEach : 0);
+			profitTotal = flippingItem.getTotalGELimit() * profitEach
+				- (plugin.getConfig().marginCheckLoss() ? profitEach : 0);
 		}
-		this.roi = calculateROI();
+		roi = calculateROI();
 	}
 
 	//Calculates the return on investment percentage.

--- a/src/main/java/com/flippingutilities/ui/flipping/FlippingPanel.java
+++ b/src/main/java/com/flippingutilities/ui/flipping/FlippingPanel.java
@@ -49,6 +49,7 @@ import java.util.stream.Collectors;
 import javax.swing.BorderFactory;
 import javax.swing.JLabel;
 import javax.swing.JMenuItem;
+import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
@@ -169,9 +170,18 @@ public class FlippingPanel extends JPanel
 			{
 				if (SwingUtilities.isLeftMouseButton(e))
 				{
-					resetPanel();
-					cardLayout.show(centerPanel, FlippingPanel.getWELCOME_PANEL());
-					rebuild(plugin.getTradesForCurrentView());
+					//Display warning message
+					final int result = JOptionPane.showOptionDialog(resetIcon, "Are you sure you want to reset the flipping panel?",
+						"Are you sure?", JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE,
+						null, new String[] {"Yes", "No"}, "No");
+
+					//If the user pressed "Yes"
+					if (result == JOptionPane.YES_OPTION)
+					{
+						resetPanel();
+						cardLayout.show(centerPanel, FlippingPanel.getWELCOME_PANEL());
+						rebuild(plugin.getTradesForCurrentView());
+					}
 				}
 			}
 

--- a/src/main/java/com/flippingutilities/ui/flipping/FlippingPanel.java
+++ b/src/main/java/com/flippingutilities/ui/flipping/FlippingPanel.java
@@ -231,6 +231,14 @@ public class FlippingPanel extends JPanel
 		add(container, BorderLayout.CENTER);
 	}
 
+	public void rebuild(List<FlippingItem> flippingItems)
+	{
+		flippingItemsPanel.removeAll();
+		SwingUtilities.invokeLater(() -> initializeFlippingPanel(flippingItems));
+		revalidate();
+		repaint();
+	}
+
 	private void initializeFlippingPanel(List<FlippingItem> flippingItems)
 	{
 		if (flippingItems == null || flippingItems.size() == 0)
@@ -288,14 +296,6 @@ public class FlippingPanel extends JPanel
 			cardLayout.show(centerPanel, WELCOME_PANEL);
 		}
 
-	}
-
-	public void rebuild(List<FlippingItem> flippingItems)
-	{
-		flippingItemsPanel.removeAll();
-		SwingUtilities.invokeLater(() -> initializeFlippingPanel(flippingItems));
-		revalidate();
-		repaint();
 	}
 
 	@Getter

--- a/src/main/java/com/flippingutilities/ui/flipping/FlippingPanel.java
+++ b/src/main/java/com/flippingutilities/ui/flipping/FlippingPanel.java
@@ -242,7 +242,6 @@ public class FlippingPanel extends JPanel
 		//Reset active panel list.
 		activePanels.clear();
 
-
 		cardLayout.show(centerPanel, ITEMS_PANEL);
 
 		int index = 0;
@@ -294,12 +293,9 @@ public class FlippingPanel extends JPanel
 	public void rebuild(List<FlippingItem> flippingItems)
 	{
 		flippingItemsPanel.removeAll();
-		SwingUtilities.invokeLater(() ->
-		{
-			initializeFlippingPanel(flippingItems);
-			revalidate();
-			repaint();
-		});
+		SwingUtilities.invokeLater(() -> initializeFlippingPanel(flippingItems));
+		revalidate();
+		repaint();
 	}
 
 	@Getter

--- a/src/main/java/com/flippingutilities/ui/statistics/StatsPanel.java
+++ b/src/main/java/com/flippingutilities/ui/statistics/StatsPanel.java
@@ -53,6 +53,7 @@ import javax.swing.BorderFactory;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JMenuItem;
+import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
@@ -226,8 +227,18 @@ public class StatsPanel extends JPanel
 			{
 				if (SwingUtilities.isLeftMouseButton(e))
 				{
-					resetPanel();
-					rebuild(plugin.getTradesForCurrentView());
+					//Display warning message
+					final int result = JOptionPane.showOptionDialog(resetIcon, "<html>Are you sure you want to reset the statistics?" +
+							"<br>This only resets the statistics within the time span</html>",
+						"Are you sure?", JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE,
+						null, new String[] {"Yes", "No"}, "No");
+
+					//If the user pressed "Yes"
+					if (result == JOptionPane.YES_OPTION)
+					{
+						resetPanel();
+						rebuild(plugin.getTradesForCurrentView());
+					}
 				}
 			}
 

--- a/src/main/java/com/flippingutilities/ui/statistics/StatsPanel.java
+++ b/src/main/java/com/flippingutilities/ui/statistics/StatsPanel.java
@@ -468,13 +468,12 @@ public class StatsPanel extends JPanel
 	{
 		//Remove old stats
 		activePanels = new ArrayList<>();
-		sortTradeList(tradesList);
 
 		SwingUtilities.invokeLater(() ->
 		{
 			statItemContainer.removeAll();
 			int index = 0;
-			for (FlippingItem item : tradesList)
+			for (FlippingItem item : sortTradeList(tradesList))
 			{
 				if (!item.hasValidOffers(HistoryManager.PanelSelection.STATS))
 				{
@@ -837,21 +836,24 @@ public class StatsPanel extends JPanel
 	}
 
 	/**
-	 * Sorts the to-be-built tradeList items according to the selectedSort string.
+	 * Clones and sorts the to-be-built tradeList items according to the selectedSort string.
 	 *
 	 * @param tradeList The soon-to-be drawn tradeList whose items are getting sorted.
+	 * @return Returns a cloned and sorted tradeList as specified by the selectedSort string.
 	 */
-	public void sortTradeList(List<FlippingItem> tradeList)
+	public List<FlippingItem> sortTradeList(List<FlippingItem> tradeList)
 	{
-		if (selectedSort == null || tradeList.isEmpty())
+		List<FlippingItem> result = new ArrayList<>(tradeList);
+
+		if (selectedSort == null || result.isEmpty())
 		{
-			return;
+			return result;
 		}
 
 		switch (selectedSort)
 		{
 			case "Most Recent":
-				tradeList.sort((item1, item2) ->
+				result.sort((item1, item2) ->
 				{
 					if (item1 == null || item2 == null)
 					{
@@ -863,11 +865,11 @@ public class StatsPanel extends JPanel
 				break;
 
 			case "Most Total Profit":
-				tradeList.sort(Comparator.comparing(item -> item.currentProfit(item.getIntervalHistory(startOfInterval))));
+				result.sort(Comparator.comparing(item -> item.currentProfit(item.getIntervalHistory(startOfInterval))));
 				break;
 
 			case "Most Profit Each":
-				tradeList.sort(Comparator.comparing(item ->
+				result.sort(Comparator.comparing(item ->
 				{
 					ArrayList<OfferInfo> intervalHistory = item.getIntervalHistory(startOfInterval);
 					int quantity = item.countItemsFlipped(intervalHistory);
@@ -882,7 +884,7 @@ public class StatsPanel extends JPanel
 				break;
 
 			case "Highest ROI":
-				tradeList.sort((item1, item2) ->
+				result.sort((item1, item2) ->
 				{
 					ArrayList<OfferInfo> intervalHistory1 = item1.getIntervalHistory(startOfInterval);
 					ArrayList<OfferInfo> intervalHistory2 = item2.getIntervalHistory(startOfInterval);
@@ -900,13 +902,15 @@ public class StatsPanel extends JPanel
 				break;
 
 			case "Highest Quantity":
-				tradeList.sort(Comparator.comparing(item -> item.countItemsFlipped(item.getIntervalHistory(startOfInterval))));
+				result.sort(Comparator.comparing(item -> item.countItemsFlipped(item.getIntervalHistory(startOfInterval))));
 				break;
 
 			default:
 				throw new IllegalStateException("Unexpected value: " + selectedSort);
 		}
-		Collections.reverse(tradeList);
+		Collections.reverse(result);
+
+		return result;
 	}
 
 }

--- a/src/main/java/com/flippingutilities/ui/statistics/StatsPanel.java
+++ b/src/main/java/com/flippingutilities/ui/statistics/StatsPanel.java
@@ -321,7 +321,7 @@ public class StatsPanel extends JPanel
 			@Override
 			public void mousePressed(MouseEvent e)
 			{
-				if (e.getButton() == MouseEvent.BUTTON1)
+				if (SwingUtilities.isLeftMouseButton(e))
 				{
 					if (subInfoContainer.isVisible())
 					{
@@ -374,6 +374,28 @@ public class StatsPanel extends JPanel
 
 		//To ensure the item's name won't wrap the whole panel.
 		mostCommonFlipVal.setMaximumSize(new Dimension(145, 0));
+
+		sessionTimePanel.addMouseListener(new MouseAdapter()
+		{
+			@Override
+			public void mousePressed(MouseEvent e)
+			{
+				if (SwingUtilities.isRightMouseButton(e))
+				{
+					//Display warning message
+					final int result = JOptionPane.showOptionDialog(resetIcon, "Are you sure you want to reset the session time?",
+						"Are you sure?", JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE,
+						null, new String[] {"Yes", "No"}, "No");
+
+					//If the user pressed "Yes"
+					if (result == JOptionPane.YES_OPTION)
+					{
+						sessionTime = Instant.now();
+						rebuild(plugin.getTradesForCurrentView());
+					}
+				}
+			}
+		});
 
 		//Wraps the total profit labels.
 		JPanel totalProfitWrapper = new JPanel(new BorderLayout());
@@ -700,7 +722,7 @@ public class StatsPanel extends JPanel
 		{
 			panel.updateTimeDisplay();
 		}
-		sessionTimePanel.setToolTipText("Resets after each client reboot");
+		sessionTimePanel.setToolTipText("Right-click to reset session timer");
 	}
 
 	/**


### PR DESCRIPTION
- Adds a warning when trying to reset any of the panels.
- Adds right-clicking the session timer inside the StatPanel to reset it. Also displays a warning just like above.
- Fix indicator if a GE limit is unknown by RuneLite.
- Fix StatPanel sorting flipping panels' items.

I'm thinking of adding the daily trade volume to the flipping panel as well, but I need to redesign the panels so that they're a bit smaller. See #45 - 4.

Edit: I've decided to put off the daily trade volume until v1.4, as it proved to have a few technicalities that I need to figure out.