### PR TITLE
Session time is now account dependent and syncs across clients

### DIFF
--- a/src/main/java/com/flippingutilities/AccountData.java
+++ b/src/main/java/com/flippingutilities/AccountData.java
@@ -26,16 +26,20 @@
 
 package com.flippingutilities;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.Data;
 
-
 @Data
 public class AccountData
 {
 	private Map<Integer, OfferInfo> lastOffers = new HashMap<>();
 	private List<FlippingItem> trades = new ArrayList<>();
+	private transient Instant sessionStartTime = Instant.now();
+	private transient Duration accumulatedSessionTime = Duration.ZERO;
+	private transient Instant lastSessionTimeUpdate;
 }

--- a/src/main/java/com/flippingutilities/AccountData.java
+++ b/src/main/java/com/flippingutilities/AccountData.java
@@ -39,7 +39,18 @@ public class AccountData
 {
 	private Map<Integer, OfferInfo> lastOffers = new HashMap<>();
 	private List<FlippingItem> trades = new ArrayList<>();
-	private transient Instant sessionStartTime = Instant.now();
-	private transient Duration accumulatedSessionTime = Duration.ZERO;
-	private transient Instant lastSessionTimeUpdate;
+	private Instant sessionStartTime = Instant.now();
+	private Duration accumulatedSessionTime = Duration.ZERO;
+	private Instant lastSessionTimeUpdate;
+
+	/**
+	 * resets all session related data associated with an account. This is only ever called when the plugin first starts
+	 * as thats when a new session is "started".
+	 */
+	public void startNewSession()
+	{
+		sessionStartTime = Instant.now();
+		accumulatedSessionTime = Duration.ZERO;
+		lastSessionTimeUpdate = null;
+	}
 }

--- a/src/main/java/com/flippingutilities/FlippingPlugin.java
+++ b/src/main/java/com/flippingutilities/FlippingPlugin.java
@@ -258,7 +258,10 @@ public class FlippingPlugin extends Plugin
 					return false;
 				}
 				previouslyLoggedIn = true;
-				handleLogin(name);
+
+				if (currentlyLoggedInAccount == null) {
+					handleLogin(name);
+				}
 				//stops scheduling this task
 				return true;
 			});

--- a/src/main/java/com/flippingutilities/FlippingPlugin.java
+++ b/src/main/java/com/flippingutilities/FlippingPlugin.java
@@ -316,7 +316,9 @@ public class FlippingPlugin extends Plugin
 		{
 			log.info("initiating load on startup");
 			TradePersister.setup();
-			return loadAllTrades();
+			Map<String, AccountData> accountsData = loadAllTrades();
+			accountsData.values().forEach(AccountData::startNewSession);
+			return accountsData;
 		}
 
 		catch (IOException e)
@@ -813,12 +815,6 @@ public class FlippingPlugin extends Plugin
 
 		String displayNameOfChangedAcc = fileName.split("\\.")[0];
 
-		if (displayNameOfChangedAcc.equals(currentlyLoggedInAccount))
-		{
-			log.info("not reloading on directory update as this client caused the directory update");
-			return;
-		}
-
 		accountCache.put(displayNameOfChangedAcc, loadTrades(displayNameOfChangedAcc));
 		if (!tabManager.getViewSelectorItems().contains(displayNameOfChangedAcc))
 		{
@@ -919,7 +915,10 @@ public class FlippingPlugin extends Plugin
 			accountCache.get(currentlyLoggedInAccount).setAccumulatedSessionTime(accumulatedSessionTime);
 			accountCache.get(currentlyLoggedInAccount).setLastSessionTimeUpdate(lastSessionTimeUpdate);
 
-			statPanel.updateSessionTimeDisplay(getAccumulatedTimeForCurrentView());
+			if (accountCurrentlyViewed.equals(ACCOUNT_WIDE) || accountCurrentlyViewed.equals(currentlyLoggedInAccount))
+			{
+				statPanel.updateSessionTimeDisplay(getAccumulatedTimeForCurrentView());
+			}
 		}
 
 		else if (currentlyLoggedInAccount != null)

--- a/src/main/java/com/flippingutilities/FlippingPlugin.java
+++ b/src/main/java/com/flippingutilities/FlippingPlugin.java
@@ -919,10 +919,7 @@ public class FlippingPlugin extends Plugin
 			accountCache.get(currentlyLoggedInAccount).setAccumulatedSessionTime(accumulatedSessionTime);
 			accountCache.get(currentlyLoggedInAccount).setLastSessionTimeUpdate(lastSessionTimeUpdate);
 
-			if (accountCurrentlyViewed.equals(currentlyLoggedInAccount))
-			{
-				statPanel.updateSessionTimeDisplay(accumulatedSessionTime);
-			}
+			statPanel.updateSessionTimeDisplay(getAccumulatedTimeForCurrentView());
 		}
 
 		else if (currentlyLoggedInAccount != null)

--- a/src/main/java/com/flippingutilities/ui/statistics/StatsPanel.java
+++ b/src/main/java/com/flippingutilities/ui/statistics/StatsPanel.java
@@ -166,9 +166,6 @@ public class StatsPanel extends JPanel
 	@Getter
 	private String selectedSort;
 
-	//Time when the panel was created. Assume this is the start of session.
-	private Instant startOfSession;
-
 	private ArrayList<StatItemPanel> activePanels = new ArrayList<>();
 
 	@Getter
@@ -188,9 +185,6 @@ public class StatsPanel extends JPanel
 
 		this.plugin = plugin;
 		this.itemManager = itemManager;
-
-		//Record start of session time.
-		startOfSession = Instant.now();
 
 		setLayout(new BorderLayout());
 
@@ -388,15 +382,14 @@ public class StatsPanel extends JPanel
 					//If the user pressed "Yes"
 					if (result == JOptionPane.YES_OPTION)
 					{
-						startOfSession = Instant.now();
-						plugin.setAccumulatedSessionTime(Duration.ZERO);
+						plugin.handleSessionTimeReset();
 						rebuild(plugin.getTradesForCurrentView());
 					}
 				}
 			}
 		});
 
-		sessionTimeVal.setText(UIUtilities.formatDuration(plugin.getAccumulatedSessionTime()));
+		sessionTimeVal.setText(UIUtilities.formatDuration(plugin.getAccumulatedTimeForCurrentView()));
 		sessionTimeVal.setPreferredSize(new Dimension(200, 0));
 		sessionTimeVal.setForeground(ColorScheme.GRAND_EXCHANGE_ALCH);
 		sessionTimePanel.setToolTipText("Right-click to reset session timer");
@@ -633,7 +626,7 @@ public class StatsPanel extends JPanel
 	 */
 	private void updateHourlyProfitDisplay()
 	{
-		double divisor = plugin.getAccumulatedSessionTime().toMillis() / 1000 * 1.0 / (60 * 60);
+		double divisor = plugin.getAccumulatedTimeForCurrentView().toMillis() / 1000 * 1.0 / (60 * 60);
 		String profitString = UIUtilities.quantityToRSDecimalStack((long) (totalProfit / divisor), true);
 		hourlyProfitVal.setText(profitString + " gp/hr");
 		hourlyProfitVal.setForeground(totalProfit >= 0 ? ColorScheme.GRAND_EXCHANGE_PRICE : UIUtilities.OUTDATED_COLOR);
@@ -794,7 +787,7 @@ public class StatsPanel extends JPanel
 				startOfInterval = timeNow.minus(30, ChronoUnit.DAYS);
 				break;
 			case "Session":
-				startOfInterval = startOfSession;
+				startOfInterval = plugin.getStartOfSessionForCurrentView();
 				break;
 			case "All":
 				startOfInterval = Instant.EPOCH;

--- a/src/main/java/com/flippingutilities/ui/statistics/StatsPanel.java
+++ b/src/main/java/com/flippingutilities/ui/statistics/StatsPanel.java
@@ -572,6 +572,7 @@ public class StatsPanel extends JPanel
 		updateSubInfoFont();
 		if (Objects.equals(timeIntervalDropdown.getSelectedItem(), "Session"))
 		{
+			updateSessionTimeDisplay(plugin.getAccumulatedTimeForCurrentView());
 			updateHourlyProfitDisplay();
 		}
 		updateRoiDisplay();

--- a/src/main/java/com/flippingutilities/ui/statistics/StatsPanel.java
+++ b/src/main/java/com/flippingutilities/ui/statistics/StatsPanel.java
@@ -572,8 +572,9 @@ public class StatsPanel extends JPanel
 		updateSubInfoFont();
 		if (Objects.equals(timeIntervalDropdown.getSelectedItem(), "Session"))
 		{
-			updateSessionTimeDisplay(plugin.getAccumulatedTimeForCurrentView());
-			updateHourlyProfitDisplay();
+			Duration accumulatedTime = plugin.getAccumulatedTimeForCurrentView();
+			updateSessionTimeDisplay(accumulatedTime);
+			updateHourlyProfitDisplay(accumulatedTime);
 		}
 		updateRoiDisplay();
 		updateRevenueAndExpenseDisplay();
@@ -625,9 +626,9 @@ public class StatsPanel extends JPanel
 	/**
 	 * Updates the hourly profit value display. Also checks and sets the font color according to profit/loss.
 	 */
-	private void updateHourlyProfitDisplay()
+	private void updateHourlyProfitDisplay(Duration accumulatedTime)
 	{
-		double divisor = plugin.getAccumulatedTimeForCurrentView().toMillis() / 1000 * 1.0 / (60 * 60);
+		double divisor = accumulatedTime.toMillis() / 1000 * 1.0 / (60 * 60);
 		String profitString = UIUtilities.quantityToRSDecimalStack((long) (totalProfit / divisor), true);
 		hourlyProfitVal.setText(profitString + " gp/hr");
 		hourlyProfitVal.setForeground(totalProfit >= 0 ? ColorScheme.GRAND_EXCHANGE_PRICE : UIUtilities.OUTDATED_COLOR);


### PR DESCRIPTION
Session time is now account dependent and syncs across clients. This was handled in a similar way as the other data that Is synced across clients and is account dependent (trades, last offers). The only difference is that every time a client starts up it resets all session related stuff in an AccountData object as its not meant to be persistent.