### PR TITLE
some small bug fixes/improvements

### DIFF
--- a/src/main/java/com/flippingutilities/FlippingPlugin.java
+++ b/src/main/java/com/flippingutilities/FlippingPlugin.java
@@ -846,7 +846,7 @@ public class FlippingPlugin extends Plugin
 		String displayNameOfChangedAcc = fileName.split("\\.")[0];
 
 		if (displayNameOfChangedAcc.equals(thisClientLastStored)) {
-			log.info("not reloading data for {} into the cache as this client was the last one to store it");
+			log.info("not reloading data for {} into the cache as this client was the last one to store it", displayNameOfChangedAcc);
 			thisClientLastStored = null;
 			return;
 		}

--- a/src/main/java/com/flippingutilities/FlippingPlugin.java
+++ b/src/main/java/com/flippingutilities/FlippingPlugin.java
@@ -159,6 +159,9 @@ public class FlippingPlugin extends Plugin
 
 	private Instant startUpTime = Instant.now();
 
+	//name of the account this client last stored trades for.
+	private String thisClientLastStored;
+
 	@Override
 	protected void startUp()
 	{
@@ -738,6 +741,7 @@ public class FlippingPlugin extends Plugin
 	{
 		try
 		{
+			thisClientLastStored = displayName;
 			TradePersister.storeTrades(displayName, accountCache.get(displayName));
 			log.info("successfully stored trades for {}", displayName);
 		}
@@ -840,6 +844,12 @@ public class FlippingPlugin extends Plugin
 	{
 
 		String displayNameOfChangedAcc = fileName.split("\\.")[0];
+
+		if (displayNameOfChangedAcc.equals(thisClientLastStored)) {
+			log.info("not reloading data for {} into the cache as this client was the last one to store it");
+			thisClientLastStored = null;
+			return;
+		}
 
 		accountCache.put(displayNameOfChangedAcc, loadTrades(displayNameOfChangedAcc));
 		if (!tabManager.getViewSelectorItems().contains(displayNameOfChangedAcc))

--- a/src/main/java/com/flippingutilities/FlippingPlugin.java
+++ b/src/main/java/com/flippingutilities/FlippingPlugin.java
@@ -842,7 +842,6 @@ public class FlippingPlugin extends Plugin
 	 */
 	public void onDirectoryUpdate(String fileName)
 	{
-
 		String displayNameOfChangedAcc = fileName.split("\\.")[0];
 
 		if (displayNameOfChangedAcc.equals(thisClientLastStored)) {
@@ -850,27 +849,29 @@ public class FlippingPlugin extends Plugin
 			thisClientLastStored = null;
 			return;
 		}
+		executor.schedule(() -> {
+			log.info("second has passed, updating cache for {}", displayNameOfChangedAcc);
+			accountCache.put(displayNameOfChangedAcc, loadTrades(displayNameOfChangedAcc));
+			if (!tabManager.getViewSelectorItems().contains(displayNameOfChangedAcc))
+			{
+				tabManager.getViewSelector().addItem(displayNameOfChangedAcc);
+			}
 
-		accountCache.put(displayNameOfChangedAcc, loadTrades(displayNameOfChangedAcc));
-		if (!tabManager.getViewSelectorItems().contains(displayNameOfChangedAcc))
-		{
-			tabManager.getViewSelector().addItem(displayNameOfChangedAcc);
-		}
+			if (accountCache.keySet().size() > 1)
+			{
+				tabManager.getViewSelector().setVisible(true);
+			}
 
-		if (accountCache.keySet().size() > 1)
-		{
-			tabManager.getViewSelector().setVisible(true);
-		}
+			updateSinceLastAccountWideBuild = true;
 
-		updateSinceLastAccountWideBuild = true;
-
-		//rebuild if you are currently looking at the account who's cache just got updated or the account wide view.
-		if (accountCurrentlyViewed.equals(ACCOUNT_WIDE) || accountCurrentlyViewed.equals(displayNameOfChangedAcc))
-		{
-			List<FlippingItem> updatedList = getTradesForCurrentView();
-			flippingPanel.rebuild(updatedList);
-			statPanel.rebuild(updatedList);
-		}
+			//rebuild if you are currently looking at the account who's cache just got updated or the account wide view.
+			if (accountCurrentlyViewed.equals(ACCOUNT_WIDE) || accountCurrentlyViewed.equals(displayNameOfChangedAcc))
+			{
+				List<FlippingItem> updatedList = getTradesForCurrentView();
+				flippingPanel.rebuild(updatedList);
+				statPanel.rebuild(updatedList);
+			}
+		}, 1000, TimeUnit.MILLISECONDS);
 	}
 
 	/**

--- a/src/main/java/com/flippingutilities/FlippingPlugin.java
+++ b/src/main/java/com/flippingutilities/FlippingPlugin.java
@@ -593,10 +593,14 @@ public class FlippingPlugin extends Plugin
 			FlippingItem item = flippingItem.get();
 			if (newOffer.isMarginCheck())
 			{
+				trades.remove(item);
+				trades.add(0, item);
 				item.updateMargin(newOffer);
 			}
 			item.updateHistory(newOffer);
 			item.updateLatestTimes(newOffer);
+
+
 		}
 		else
 		{

--- a/src/main/java/com/flippingutilities/ui/statistics/StatsPanel.java
+++ b/src/main/java/com/flippingutilities/ui/statistics/StatsPanel.java
@@ -629,7 +629,15 @@ public class StatsPanel extends JPanel
 	private void updateHourlyProfitDisplay(Duration accumulatedTime)
 	{
 		double divisor = accumulatedTime.toMillis() / 1000 * 1.0 / (60 * 60);
-		String profitString = UIUtilities.quantityToRSDecimalStack((long) (totalProfit / divisor), true);
+		String profitString;
+		//i think this happens when the profit is absurdly high because the session time is very low (offers come in
+		//just as you start a new session)
+		try {
+			profitString = UIUtilities.quantityToRSDecimalStack((long) (totalProfit / divisor), true);
+		}
+		catch (ArrayIndexOutOfBoundsException e) {
+			profitString = "NA";
+		}
 		hourlyProfitVal.setText(profitString + " gp/hr");
 		hourlyProfitVal.setForeground(totalProfit >= 0 ? ColorScheme.GRAND_EXCHANGE_PRICE : UIUtilities.OUTDATED_COLOR);
 		hourlyProfitPanel.setToolTipText("Hourly profit as determined by the session time");


### PR DESCRIPTION
- i had made a change sometime ago with this code and had accidently deleted the logic for re positioning items if they are present and its a margin check. 
- cache updater was too eager in reloading data so I made it not reload in the case when the this client was responsible for storing the trades which causes the file modification event.
-  I also noticed that when session time was really small I would get an index out of bounds error in quantityToRsDecimalStack. Presumably because the divisor too small. I added a try catch and set the profit string to a default value in that case.
- added one second delay before reloading trades into cache in onDirectoryUpdate as it was trying to reload before the other client finished storing trades which was causing errors